### PR TITLE
TauTuple: store track kinematic and track quality parameters 

### DIFF
--- a/Analysis/interface/TauTuple.h
+++ b/Analysis/interface/TauTuple.h
@@ -11,6 +11,7 @@
 #define CAND_VAR(type, name) VAR(std::vector<type>, pfCand_##name)
 #define ELE_VAR(type, name) VAR(std::vector<type>, ele_##name)
 #define MUON_VAR(type, name) VAR(std::vector<type>, muon_##name)
+#define TRACK_VAR(type, name) VAR(std::vector<type>, track_##name)
 
 #define VAR2(type, name1, name2) VAR(type, name1) VAR(type, name2)
 #define VAR3(type, name1, name2, name3) VAR2(type, name1, name2) VAR(type, name3)
@@ -27,6 +28,10 @@
 #define MUON_VAR2(type, name1, name2) MUON_VAR(type, name1) MUON_VAR(type, name2)
 #define MUON_VAR3(type, name1, name2, name3) MUON_VAR2(type, name1, name2) MUON_VAR(type, name3)
 #define MUON_VAR4(type, name1, name2, name3, name4) MUON_VAR3(type, name1, name2, name3) MUON_VAR(type, name4)
+
+#define TRACK_VAR2(type, name1, name2) TRACK_VAR(type, name1) TRACK_VAR(type, name2)
+#define TRACK_VAR3(type, name1, name2, name3) TRACK_VAR2(type, name1, name2) TRACK_VAR(type, name3)
+#define TRACK_VAR4(type, name1, name2, name3, name4) TRACK_VAR3(type, name1, name2, name3) TRACK_VAR(type, name4)
 
 #define TAU_DATA() \
     /* Event Variables */ \
@@ -237,6 +242,32 @@
                      n_hits_CSC_4) /* number of valid and bad hits for the CSC subdetector stations */ \
     MUON_VAR4(Int_t, n_hits_RPC_1, n_hits_RPC_2, n_hits_RPC_3, \
                      n_hits_RPC_4) /* number of valid and bad hits for the RPC subdetector stations */ \
+    /* PAT IsolatedTrack*/ \
+    TRACK_VAR4(Float_t, pt, eta, phi, mass) /* 4-momentum of the PF candidate */ \
+    TRACK_VAR4(Int_t, pfIsoCH, \
+                      pfIsoNH, \
+                      pfIsoPh, \
+                      pfIsoPu) /* 4 components of isolation (charged hadron, neutral hadron, photon, pileup) */ \
+    TRACK_VAR(Int_t, fromPV) /* the association to PV=ipv. >=PVLoose corresponds to JME definition,
+                               >=PVTight to isolation definition:
+                               NoPV = 0, PVLoose = 1, PVTight = 2, PVUsedInFit = 3 */ \
+    TRACK_VAR(Int_t, pdgId) /* PDG identifier */ \
+    TRACK_VAR(Int_t, charge) /* electric charge */ \
+    TRACK_VAR(Float_t, dxy) /* signed transverse impact parameter wrt to the primary vertex */ \
+    TRACK_VAR(Float_t, dxy_error) /* uncertainty of the transverse impact parameter measurement */ \
+    TRACK_VAR(Float_t, dz) /* dz wrt to the primary vertex */ \
+    TRACK_VAR(Float_t, dz_error) /* uncertainty of the dz measurement */ \
+    TRACK_VAR(Float_t, matchedCaloJetEmEnergy) /* EM energies of the nearest calo-jet within dR=0.3*/ \
+    TRACK_VAR(Float_t, matchedCaloJetHadEnergy) /* Hadronic energies of the nearest calo-jet within dR=0.3*/ \
+    TRACK_VAR3(Int_t, isHighPurityTrack, isTightTrack, isLooseTrack) /* track Quality */ \
+    TRACK_VAR(Float_t, dEdxStrip) /* estimated dE/dx values in the strips */ \
+    TRACK_VAR(Float_t, dEdxPixel) /*  estimated dE/dx values in the pixels */ \
+    TRACK_VAR(Float_t, deltaEta) /**/ \
+    TRACK_VAR(Float_t, deltaPhi) /* the difference in eta/phi between the initial track trajectory and
+                                    the point of intersection with the Ecal.  Can be used to identify
+                                    roughly the calorimeter cells the track should hit.*/ \
+    TRACK_VAR(Int_t, n_ValidHits) /* number Of Valid Hits */ \
+    TRACK_VAR(Int_t, n_InactiveHits) /* number Of Inactive Hits */ \
     /**/
 
 #define VAR(type, name) DECLARE_BRANCH_VARIABLE(type, name)
@@ -262,6 +293,10 @@ INITIALIZE_TREE(tau_tuple, TauTuple, TAU_DATA)
 #undef MUON_VAR2
 #undef MUON_VAR3
 #undef MUON_VAR4
+#undef TRACK_VAR
+#undef TRACK_VAR2
+#undef TRACK_VAR3
+#undef TRACK_VAR4
 #undef TAU_ID
 
 namespace tau_tuple {

--- a/Analysis/interface/TauTuple.h
+++ b/Analysis/interface/TauTuple.h
@@ -243,22 +243,15 @@
     MUON_VAR4(Int_t, n_hits_RPC_1, n_hits_RPC_2, n_hits_RPC_3, \
                      n_hits_RPC_4) /* number of valid and bad hits for the RPC subdetector stations */ \
     /* PAT IsolatedTrack*/ \
-    TRACK_VAR4(Float_t, pt, eta, phi, mass) /* 4-momentum of the PF candidate */ \
-    TRACK_VAR4(Int_t, pfIsoCH, \
-                      pfIsoNH, \
-                      pfIsoPh, \
-                      pfIsoPu) /* 4 components of isolation (charged hadron, neutral hadron, photon, pileup) */ \
+    TRACK_VAR3(Float_t, pt, eta, phi) /* track kinematics */ \
     TRACK_VAR(Int_t, fromPV) /* the association to PV=ipv. >=PVLoose corresponds to JME definition,
                                >=PVTight to isolation definition:
                                NoPV = 0, PVLoose = 1, PVTight = 2, PVUsedInFit = 3 */ \
-    TRACK_VAR(Int_t, pdgId) /* PDG identifier */ \
     TRACK_VAR(Int_t, charge) /* electric charge */ \
     TRACK_VAR(Float_t, dxy) /* signed transverse impact parameter wrt to the primary vertex */ \
     TRACK_VAR(Float_t, dxy_error) /* uncertainty of the transverse impact parameter measurement */ \
     TRACK_VAR(Float_t, dz) /* dz wrt to the primary vertex */ \
     TRACK_VAR(Float_t, dz_error) /* uncertainty of the dz measurement */ \
-    TRACK_VAR(Float_t, matchedCaloJetEmEnergy) /* EM energies of the nearest calo-jet within dR=0.3*/ \
-    TRACK_VAR(Float_t, matchedCaloJetHadEnergy) /* Hadronic energies of the nearest calo-jet within dR=0.3*/ \
     TRACK_VAR3(Int_t, isHighPurityTrack, isTightTrack, isLooseTrack) /* track Quality */ \
     TRACK_VAR(Float_t, dEdxStrip) /* estimated dE/dx values in the strips */ \
     TRACK_VAR(Float_t, dEdxPixel) /*  estimated dE/dx values in the pixels */ \
@@ -268,6 +261,26 @@
                                     roughly the calorimeter cells the track should hit.*/ \
     TRACK_VAR(Int_t, n_ValidHits) /* number Of Valid Hits */ \
     TRACK_VAR(Int_t, n_InactiveHits) /* number Of Inactive Hits */ \
+    TRACK_VAR3(Int_t, n_LostHits_0, \
+                      n_LostHits_1, \
+                      n_LostHits_2) /* number Of Lost Hits
+                                       0 -> TRACK_HITS,
+                                       1 -> MISSING_INNER_HITS,
+                                       2 -> MISSING_OUTER_HITS*/ \
+    TRACK_VAR(Int_t, n_ValidPixelHits) /* number Of Valid Pixel Hits */ \
+    TRACK_VAR(Int_t, n_ValidStripHits) /* number Of Valid Strip Hits */ \
+    TRACK_VAR3(Int_t, n_LostPixelHits_0, \
+                      n_LostPixelHits_1, \
+                      n_LostPixelHits_2) /* number Of Lost Pixe Hits
+                                           0 -> TRACK_HITS,
+                                           1 -> MISSING_INNER_HITS,
+                                           2 -> MISSING_OUTER_HITS */ \
+    TRACK_VAR3(Int_t, n_LostStripHits_0, \
+                      n_LostStripHits_1, \
+                      n_LostStripHits_2) /* number Of Lost Strip Hits
+                                          0 -> TRACK_HITS,
+                                          1 -> MISSING_INNER_HITS,
+                                          2 -> MISSING_OUTER_HITS */ \
     /**/
 
 #define VAR(type, name) DECLARE_BRANCH_VARIABLE(type, name)

--- a/Production/interface/TauJet.h
+++ b/Production/interface/TauJet.h
@@ -8,6 +8,7 @@
 #include "DataFormats/PatCandidates/interface/Tau.h"
 #include "DataFormats/PatCandidates/interface/Jet.h"
 #include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+#include "DataFormats/PatCandidates/interface/IsolatedTrack.h"
 
 #include "GenTruthTools.h"
 
@@ -29,6 +30,7 @@ struct TauJet {
     std::vector<PFCandDesc> cands;
     std::vector<const pat::Electron*> electrons;
     std::vector<const pat::Muon*> muons;
+    std::vector<const pat::IsolatedTrack*> tracks;
     gen_truth::LeptonMatchResult jetGenLeptonMatchResult, tauGenLeptonMatchResult;
     gen_truth::QcdMatchResult jetGenQcdMatchResult, tauGenQcdMatchResult;
 
@@ -53,7 +55,8 @@ public:
 
     TauJetBuilder(const TauJetBuilderSetup& setup, const pat::JetCollection& jets, const pat::TauCollection& taus,
                   const pat::PackedCandidateCollection& cands, const pat::ElectronCollection& electrons,
-                  const pat::MuonCollection& muons, const reco::GenParticleCollection* genParticles);
+                  const pat::MuonCollection& muons, const pat::IsolatedTrackCollection& tracks,
+                  const reco::GenParticleCollection* genParticles);
 
     TauJetBuilder(const TauJetBuilder&) = delete;
     TauJetBuilder& operator=(const TauJetBuilder&) = delete;
@@ -73,6 +76,7 @@ private:
     std::vector<PFCandDesc> FindMatchedPFCandidates(const pat::Jet* jet, const pat::Tau* tau) const;
     std::vector<const pat::Electron*> FindMatchedElectrons(const pat::Jet* jet, const pat::Tau* tau) const;
     std::vector<const pat::Muon*> FindMatchedMuons(const pat::Jet* jet, const pat::Tau* tau) const;
+    std::vector<const pat::IsolatedTrack*> FindMatchedTracks(const pat::Jet* jet, const pat::Tau* tau) const;
 
 private:
     const TauJetBuilderSetup setup_;
@@ -81,6 +85,7 @@ private:
     const pat::PackedCandidateCollection& cands_;
     const pat::ElectronCollection& electrons_;
     const pat::MuonCollection& muons_;
+    const pat::IsolatedTrackCollection& tracks_;
     const reco::GenParticleCollection* genParticles_;
 
     IndexSet availableJets_, processedJets_;

--- a/Production/plugins/TauTupleProducer.cc
+++ b/Production/plugins/TauTupleProducer.cc
@@ -15,6 +15,7 @@
 #include "DataFormats/PatCandidates/interface/Jet.h"
 #include "DataFormats/PatCandidates/interface/PackedCandidate.h"
 #include "DataFormats/PatCandidates/interface/IsolatedTrack.h"
+#include "DataFormats/TrackReco/interface/HitPattern.h"
 
 #include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
 #include "AnalysisDataFormats/TopObjects/interface/TtGenEvent.h"
@@ -336,7 +337,7 @@ private:
             FillPFCandidates(tauJet.cands);
             FillElectrons(tauJet.electrons);
             FillMuons(tauJet.muons);
-            FillTracks(tauJet.tracks); // no matching
+            FillTracks(tauJet.tracks);
 
             tauTuple.Fill();
         }
@@ -533,25 +534,12 @@ private:
           tauTuple().track_pt.push_back(static_cast<float>(track->polarP4().pt()));
           tauTuple().track_eta.push_back(static_cast<float>(track->polarP4().eta()));
           tauTuple().track_phi.push_back(static_cast<float>(track->polarP4().phi()));
-          tauTuple().track_mass.push_back(static_cast<float>(track->polarP4().mass()));
-
-          const auto& PFisolation = track->pfIsolationDR03();
-          tauTuple().track_pfIsoCH.push_back(static_cast<float>(PFisolation.chargedHadronIso()));
-          tauTuple().track_pfIsoNH.push_back(static_cast<float>(PFisolation.neutralHadronIso()));
-          tauTuple().track_pfIsoPh.push_back(static_cast<float>(PFisolation.photonIso()));
-          tauTuple().track_pfIsoPu.push_back(static_cast<float>(PFisolation.puChargedHadronIso()));
-
           tauTuple().track_fromPV.push_back(track->fromPV());
-          tauTuple().track_pdgId.push_back(track->pdgId());
           tauTuple().track_charge.push_back(track->charge());
-
           tauTuple().track_dxy.push_back(track->dxy());
           tauTuple().track_dxy_error.push_back(track->dxyError());
           tauTuple().track_dz.push_back(track->dz());
           tauTuple().track_dz_error.push_back(track->dzError());
-
-          tauTuple().track_matchedCaloJetEmEnergy.push_back(track->matchedCaloJetEmEnergy());
-          tauTuple().track_matchedCaloJetHadEnergy.push_back(track->matchedCaloJetHadEnergy());
           tauTuple().track_isHighPurityTrack.push_back(track->isHighPurityTrack());
           tauTuple().track_isTightTrack.push_back(track->isTightTrack());
           tauTuple().track_isLooseTrack.push_back(track->isLooseTrack());
@@ -563,6 +551,18 @@ private:
           const auto& hitPattern = track->hitPattern();
           tauTuple().track_n_ValidHits.push_back(hitPattern.numberOfValidHits());
           tauTuple().track_n_InactiveHits.push_back(hitPattern.numberOfInactiveHits());
+          tauTuple().track_n_ValidPixelHits.push_back(hitPattern.numberOfValidPixelHits());
+          tauTuple().track_n_ValidStripHits.push_back(hitPattern.numberOfValidStripHits());
+          using ctgr = reco::HitPattern;
+          tauTuple().track_n_LostHits_0.push_back(hitPattern.numberOfLostHits(ctgr::TRACK_HITS));
+          tauTuple().track_n_LostHits_1.push_back(hitPattern.numberOfLostHits(ctgr::MISSING_INNER_HITS));
+          tauTuple().track_n_LostHits_2.push_back(hitPattern.numberOfLostHits(ctgr::MISSING_OUTER_HITS));
+          tauTuple().track_n_LostPixelHits_0.push_back(hitPattern.numberOfLostPixelHits(ctgr::TRACK_HITS));
+          tauTuple().track_n_LostPixelHits_1.push_back(hitPattern.numberOfLostPixelHits(ctgr::MISSING_INNER_HITS));
+          tauTuple().track_n_LostPixelHits_2.push_back(hitPattern.numberOfLostPixelHits(ctgr::MISSING_OUTER_HITS));
+          tauTuple().track_n_LostStripHits_0.push_back(hitPattern.numberOfLostStripHits(ctgr::TRACK_HITS));
+          tauTuple().track_n_LostStripHits_1.push_back(hitPattern.numberOfLostStripHits(ctgr::MISSING_INNER_HITS));
+          tauTuple().track_n_LostStripHits_2.push_back(hitPattern.numberOfLostStripHits(ctgr::MISSING_OUTER_HITS));
 
         }
     }

--- a/Production/plugins/TauTupleProducer.cc
+++ b/Production/plugins/TauTupleProducer.cc
@@ -14,6 +14,7 @@
 #include "DataFormats/PatCandidates/interface/Tau.h"
 #include "DataFormats/PatCandidates/interface/Jet.h"
 #include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+#include "DataFormats/PatCandidates/interface/IsolatedTrack.h"
 
 #include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
 #include "AnalysisDataFormats/TopObjects/interface/TtGenEvent.h"
@@ -131,6 +132,7 @@ public:
         taus_token(consumes<pat::TauCollection>(cfg.getParameter<edm::InputTag>("taus"))),
         jets_token(consumes<pat::JetCollection>(cfg.getParameter<edm::InputTag>("jets"))),
         cands_token(consumes<pat::PackedCandidateCollection>(cfg.getParameter<edm::InputTag>("pfCandidates"))),
+        tracks_token(consumes<pat::IsolatedTrackCollection>(cfg.getParameter<edm::InputTag>("tracks"))),
         data(TauTupleProducerData::RequestGlobalData()),
         tauTuple(data->tauTuple),
         summaryTuple(data->summaryTuple)
@@ -198,13 +200,16 @@ private:
         edm::Handle<pat::PackedCandidateCollection> cands;
         event.getByToken(cands_token, cands);
 
+        edm::Handle<pat::IsolatedTrackCollection> tracks;
+        event.getByToken(tracks_token, tracks);
+
         edm::Handle<std::vector<reco::GenParticle>> hGenParticles;
         if(isMC)
             event.getByToken(genParticles_token, hGenParticles);
 
         auto genParticles = hGenParticles.isValid() ? hGenParticles.product() : nullptr;
 
-        TauJetBuilder builder(builderSetup, *jets, *taus, *cands, *electrons, *muons, genParticles);
+        TauJetBuilder builder(builderSetup, *jets, *taus, *cands, *electrons, *muons, *tracks, genParticles);
         const auto tauJets = builder.Build();
 
         for(const TauJet& tauJet : tauJets) {
@@ -331,6 +336,7 @@ private:
             FillPFCandidates(tauJet.cands);
             FillElectrons(tauJet.electrons);
             FillMuons(tauJet.muons);
+            FillTracks(tauJet.tracks); // no matching
 
             tauTuple.Fill();
         }
@@ -520,6 +526,47 @@ private:
         }
     }
 
+    void FillTracks(const std::vector<const pat::IsolatedTrack*>& tracks)
+    {
+        for(const pat::IsolatedTrack* track: tracks) {
+
+          tauTuple().track_pt.push_back(static_cast<float>(track->polarP4().pt()));
+          tauTuple().track_eta.push_back(static_cast<float>(track->polarP4().eta()));
+          tauTuple().track_phi.push_back(static_cast<float>(track->polarP4().phi()));
+          tauTuple().track_mass.push_back(static_cast<float>(track->polarP4().mass()));
+
+          const auto& PFisolation = track->pfIsolationDR03();
+          tauTuple().track_pfIsoCH.push_back(static_cast<float>(PFisolation.chargedHadronIso()));
+          tauTuple().track_pfIsoNH.push_back(static_cast<float>(PFisolation.neutralHadronIso()));
+          tauTuple().track_pfIsoPh.push_back(static_cast<float>(PFisolation.photonIso()));
+          tauTuple().track_pfIsoPu.push_back(static_cast<float>(PFisolation.puChargedHadronIso()));
+
+          tauTuple().track_fromPV.push_back(track->fromPV());
+          tauTuple().track_pdgId.push_back(track->pdgId());
+          tauTuple().track_charge.push_back(track->charge());
+
+          tauTuple().track_dxy.push_back(track->dxy());
+          tauTuple().track_dxy_error.push_back(track->dxyError());
+          tauTuple().track_dz.push_back(track->dz());
+          tauTuple().track_dz_error.push_back(track->dzError());
+
+          tauTuple().track_matchedCaloJetEmEnergy.push_back(track->matchedCaloJetEmEnergy());
+          tauTuple().track_matchedCaloJetHadEnergy.push_back(track->matchedCaloJetHadEnergy());
+          tauTuple().track_isHighPurityTrack.push_back(track->isHighPurityTrack());
+          tauTuple().track_isTightTrack.push_back(track->isTightTrack());
+          tauTuple().track_isLooseTrack.push_back(track->isLooseTrack());
+          tauTuple().track_dEdxStrip.push_back(track->dEdxStrip());
+          tauTuple().track_dEdxPixel.push_back(track->dEdxPixel());
+          tauTuple().track_deltaEta.push_back(track->deltaEta());
+          tauTuple().track_deltaPhi.push_back(track->deltaPhi());
+
+          const auto& hitPattern = track->hitPattern();
+          tauTuple().track_n_ValidHits.push_back(hitPattern.numberOfValidHits());
+          tauTuple().track_n_InactiveHits.push_back(hitPattern.numberOfInactiveHits());
+
+        }
+    }
+
     static float CalculateGottfriedJacksonAngleDifference(const pat::Tau& tau)
     {
         double gj_diff;
@@ -565,6 +612,7 @@ private:
     edm::EDGetTokenT<pat::TauCollection> taus_token;
     edm::EDGetTokenT<pat::JetCollection> jets_token;
     edm::EDGetTokenT<pat::PackedCandidateCollection> cands_token;
+    edm::EDGetTokenT<pat::IsolatedTrackCollection> tracks_token;
 
     TauTupleProducerData* data;
     tau_tuple::TauTuple& tauTuple;

--- a/Production/python/Production.py
+++ b/Production/python/Production.py
@@ -29,7 +29,7 @@ options.register('requireGenMatch', True, VarParsing.multiplicity.singleton, Var
 
 options.parseArguments()
 
-sampleConfig = importlib.import_module('TauML.Production.sampleConfig')
+sampleConfig = importlib.import_module('TauMLTools.Production.sampleConfig')
 isData = sampleConfig.IsData(options.sampleType)
 period = sampleConfig.GetPeriod(options.sampleType)
 
@@ -103,6 +103,7 @@ process.tauTupleProducer = cms.EDAnalyzer('TauTupleProducer',
     taus            = tauSrc_InputTag,
     jets            = cms.InputTag('slimmedJets'),
     pfCandidates    = cms.InputTag('packedPFCandidates'),
+    tracks          = cms.InputTag('isolatedTracks'),
 )
 
 process.tupleProductionSequence = cms.Sequence(process.tauTupleProducer)


### PR DESCRIPTION
The following track parameters have been added:
1. pt eta, phi, mass - 4-momentum of the track 
2. pfIsoCH,pfIsoNH,pfIsoPh, pfIsoPu - 4 components of isolation (charged hadron, neutral hadron, photon, pileup) 
3. fromPV -  the association to PV=ipv. >=PVLoose corresponds to JME definition,
                           >=PVTight to isolation definition:
                            NoPV = 0, PVLoose = 1, PVTight = 2, PVUsedInFit = 3 
6. pdgId -  PDG identifier 
7. charge -  electric charge 
8. dxy - signed transverse impact parameter wrt to the primary vertex 
9. dxy_error -  uncertainty of the transverse impact parameter measurement 
10. dz -  dz wrt to the primary vertex 
11. dz_error -  uncertainty of the dz measurement 
12. matchedCaloJetEmEnergy -  EM energies of the nearest calo-jet within dR=0.3
13. matchedCaloJetHadEnergy -  Hadronic energies of the nearest calo-jet within dR=0.3
14. isHighPurityTrack - isTightTrack, isLooseTrack - track Quality 
15. dEdxStrip - estimated dE/dx values in the strips 
16. dEdxPixel -  estimated dE/dx values in the pixels 
17. deltaEta, deltaPhi -  the difference in eta/phi between the initial track trajectory and
                                 the point of intersection with the Ecal.  Can be used to identify
                                 roughly the calorimeter cells the track should hit.
20. n_ValidHits -  number Of Valid Hits 
21. n_InactiveHits -  number Of Inactive Hits