### PR TITLE
Small adaptions after submitting the Phase 2 offline TauTuple Production

### DIFF
--- a/Production/crab/configs/Phase2_110X/QCD.txt
+++ b/Production/crab/configs/Phase2_110X/QCD.txt
@@ -4,4 +4,3 @@ QCD_Pt-15to3000_NoPU         /QCD_Pt-15to3000_TuneCP5_Flat_14TeV-pythia8/Phase2H
 QCD_Pt-15to3000_PU140        /QCD_Pt-15to3000_TuneCP5_Flat_14TeV-pythia8/Phase2HLTTDRWinter20RECOMiniAOD-PU140_castor_110X_mcRun4_realistic_v3-v2/MINIAODSIM
 QCD_Pt-15to3000_PU200        /QCD_Pt-15to3000_TuneCP5_Flat_14TeV-pythia8/Phase2HLTTDRWinter20RECOMiniAOD-PU200_castor_110X_mcRun4_realistic_v3-v2/MINIAODSIM
 QCD_Pt-15to7000_NoPU         /QCD_Pt-15to7000_TuneCP5_Flat_14TeV-pythia8/Phase2HLTTDRWinter20RECOMiniAOD-NoPU_castor_110X_mcRun4_realistic_v3-v1/MINIAODSIM
-QCD_Pt-15to7000_FlatPU0To200 /QCD_Pt-15to7000_TuneCP5_Flat_14TeV-pythia8/Phase2HLTTDRWinter20RECOMiniAOD-FlatPU0To200_castor_110X_mcRun4_realistic_v3-v2/MINIAODSIM

--- a/Production/scripts/crab_submit.py
+++ b/Production/scripts/crab_submit.py
@@ -32,6 +32,8 @@ parser.add_argument('--maxMemory', required=False, type=int, default=2000,
 					help="maximum amount of memory (in MB) a job is allowed to use (default: 2000 MB )")
 parser.add_argument('--numCores', required=False, type=int, default=1, help="number of cores per job (default: 1)")
 parser.add_argument('--allowNonValid', action="store_true", help="Allow nonvalid dataset as an input.")
+parser.add_argument('--vomsGroup',required=False, type=str, default="", help="custom VOMS group of used proxy")
+parser.add_argument('--vomsRole', required=False, type=str, default="", help="custom VOMS role of used proxy")
 parser.add_argument('job_file', type=str, nargs='+', help="text file with jobs descriptions")
 args = parser.parse_args()
 

--- a/Production/scripts/crab_submit_file.py
+++ b/Production/scripts/crab_submit_file.py
@@ -33,6 +33,8 @@ parser.add_argument('--maxMemory', required=False, type=int, default=2000,
 					help="maximum amount of memory (in MB) a job is allowed to use (default: 2000 MB )")
 parser.add_argument('--numCores', required=False, type=int, default=1, help="number of cores per job (default: 1)")
 parser.add_argument('--allowNonValid', action="store_true", help="Allow nonvalid dataset as an input.")
+parser.add_argument('--vomsGroup',required=False, type=str, default="", help="custom VOMS group of used proxy")
+parser.add_argument('--vomsRole', required=False, type=str, default="", help="custom VOMS role of used proxy")
 parser.add_argument('--jobFile', required=True, type=str, help="text file with jobs descriptions")
 args = parser.parse_args()
 
@@ -57,6 +59,11 @@ config.General.transferLogs = False
 config.Data.publication = False
 
 config.Site.storageSite = args.site
+
+if len(args.vomsGroup) != 0:
+    config.User.voGroup = args.vomsGroup
+if len(args.vomsRole) != 0:
+    config.User.voRole = args.vomsRole
 
 if args.output[0] == '/':
     config.Data.outLFNDirBase = args.output


### PR DESCRIPTION
Changes:

- remove INVALID sample in QCD list
- add the possibility to specify a custom group and role for the VOMS proxy used (needed to write e.g. to KIT user dCache)