### PR TITLE
adding validation tool (KS test)

### DIFF
--- a/Production/scripts/validation_tool.py
+++ b/Production/scripts/validation_tool.py
@@ -132,7 +132,7 @@ if __name__ == '__main__':
 
   ## first, run on plain columns
   dataframe = ROOT.RDataFrame('taus', input_files)
-  run_validation(dataframe = dataframe, pwd = main_dir, branches = ['lepton_gen_match', 'sampleType', 'dataset_group_id'])
+  run_validation(dataframe = dataframe, pwd = main_dir, branches = ['lepton_gen_match', 'sampleType', 'dataset_group_id', 'dataset_id'])
 
   ## then, group by tau type
   tau_type_dataframes = groupby(dataframe = dataframe, by = 'lepton_gen_match')
@@ -148,6 +148,11 @@ if __name__ == '__main__':
   group_id_dataframes = groupby(dataframe = dataframe, by = 'dataset_group_id')
   for ii, df in group_id_dataframes.iteritems():
     run_validation(dataframe = df, pwd = '/'.join([main_dir, 'dataset_group_id', str(ii)]), branches = ['tau_pt', 'tau_eta', 'dataset_id'])
+
+  ## then, group by dataset id
+  group_id_dataframes = groupby(dataframe = dataframe, by = 'dataset_id')
+  for ii, df in group_id_dataframes.iteritems():
+    run_validation(dataframe = df, pwd = '/'.join([main_dir, 'dataset_id', str(ii)]), branches = ['tau_pt', 'tau_eta'])
 
   OUTPUT_ROOT.Close()
   json.dump(JSON_DICT, OUTPUT_JSON, indent = 4)

--- a/Production/scripts/validation_tool.py
+++ b/Production/scripts/validation_tool.py
@@ -12,7 +12,7 @@ import glob
 import json
 from collections import OrderedDict
 
-parser.add_argument('--input'       , required = True, type = str, help = 'input file. Accepts glob patterns')
+parser.add_argument('--input'       , required = True, type = str, help = 'input file. Accepts glob patterns (use quotes)')
 parser.add_argument('--output'      , required = True, type = str, help = 'output file name')
 parser.add_argument('--pdf'         , default  = None, type = str, help = 'output pdf directory')
 parser.add_argument('--json'        , required = True, type = str, help = 'output json file name')

--- a/Production/scripts/validation_tool.py
+++ b/Production/scripts/validation_tool.py
@@ -55,7 +55,7 @@ def groupby(dataframe, by):
   return {tt: dataframe.Filter('{} == {}'.format(by, tt)) for tt in types}
 
 def get_histos(dataframe, branch, norm = False):
-  size = int(dataframe.Count())
+  size = dataframe.Count().GetValue()
   sub_size = 1 + size // N_SPLITS
   subframes = [dataframe.Range(ii*sub_size, (ii+1)*sub_size) for ii in range(N_SPLITS)]
   

--- a/Production/scripts/validation_tool.py
+++ b/Production/scripts/validation_tool.py
@@ -51,6 +51,7 @@ def groupby(dataframe, by):
   hist = _.GetValue()
   hist.ClearUnderflowAndOverflow()
   types = list(set([round(hist.GetBinCenter(jj)) for jj in range(hist.GetNbinsX()) if hist.GetBinContent(jj)]))
+  types = [int(tt) for tt in types]
 
   return {tt: dataframe.Filter('{} == {}'.format(by, tt)) for tt in types}
 

--- a/Production/scripts/validation_tool.py
+++ b/Production/scripts/validation_tool.py
@@ -64,8 +64,9 @@ def get_histos(dataframe, branch, norm = False):
   hptrs = [sf.Histo1D(model, branch) for sf in subframes]
   histos = [hh.GetValue().Clone() for hh in hptrs]
   
-  for hh in histos:
+  for ii, hh in enumerate(histos):
     hh.SetTitle(branch)
+    hh.SetName('_'.join([hh.GetName(), ii]))
     hh.Sumw2()
     hh.ClearUnderflowAndOverflow()
     if norm and hh.Integral():

--- a/Production/scripts/validation_tool.py
+++ b/Production/scripts/validation_tool.py
@@ -63,10 +63,10 @@ def get_histos(dataframe, branch, norm = False):
   model = (branch, "") + BINS[branch]
   hptrs = [sf.Histo1D(model, branch) for sf in subframes]
   histos = [hh.GetValue().Clone() for hh in hptrs]
-  
+
   for ii, hh in enumerate(histos):
     hh.SetTitle(branch)
-    hh.SetName('_'.join([hh.GetName(), ii]))
+    hh.SetName('_'.join([hh.GetName(), str(ii)]))
     hh.Sumw2()
     hh.ClearUnderflowAndOverflow()
     if norm and hh.Integral():

--- a/Production/scripts/validation_tool.py
+++ b/Production/scripts/validation_tool.py
@@ -112,18 +112,18 @@ def run_validation(dataframe, branches, pwd):
 
     pvalues = [histos[0].KolmogorovTest(hh) if histos[0].Integral()*hh.Integral() else 99 for hh in histos]
     if not histos[0].Integral():
-      print '[WARNING] control histogram is empty for step {} inside {}'.format(branch, pwd)
+      print ('[WARNING] control histogram is empty for step {} inside {}'.format(branch, pwd))
     
     if not all([pv >= PVAL_THRESHOLD for pv in pvalues]):
-      print '[WARNING] KS test failed for step {} inside {}. p-values are:'.format(branch, pwd)
-      print '\t', pvalues
+      print ('[WARNING] KS test failed for step {} inside {}. p-values are:'.format(branch, pwd))
+      print ('\t', pvalues)
     
     JSON_DICT[pwd][branch] = pvalues
     
     save_histos(histos, fdir = '/'.join([pwd, branch]), pvalues = pvalues)
 
 if __name__ == '__main__':
-  print '[INFO] reading files', args.input
+  print ('[INFO] reading files', args.input)
   input_files = ROOT.std.vector('std::string')()
   for file in glob.glob(args.input):
     input_files.push_back(str(file))
@@ -156,4 +156,4 @@ if __name__ == '__main__':
 
   OUTPUT_ROOT.Close()
   json.dump(JSON_DICT, OUTPUT_JSON, indent = 4)
-  print '[INFO] all done. Files', args.output, 'and', args.json, 'have been created'
+  print ('[INFO] all done. Files', args.output, 'and', args.json, 'have been created')

--- a/Production/scripts/validation_tool.py
+++ b/Production/scripts/validation_tool.py
@@ -56,7 +56,7 @@ def groupby(dataframe, by):
 
 def get_histos(dataframe, branch, norm = False):
   size = int(dataframe.Count())
-  sub_size = 1 + size / N_SPLITS
+  sub_size = 1 + size // N_SPLITS
   subframes = [dataframe.Range(ii*sub_size, (ii+1)*sub_size) for ii in range(N_SPLITS)]
   
   model = (branch, "") + BINS[branch]

--- a/Production/scripts/validation_tool.py
+++ b/Production/scripts/validation_tool.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python
+import argparse
+parser = argparse.ArgumentParser('''
+The script runs a binned KS test between different chunks of the same RDataFrame. For simplicity, all chunks are compared to the first one.
+If a KS test is below the threshold, a warning message is printed on screen.
+NOTE: pvalue = 99 means that one of the two histograms is empty.
+''')
+
+import ROOT
+import glob
+import json
+from collections import OrderedDict
+
+parser.add_argument('--input'       , required = True, type = str, help = 'input file. Accepts glob patterns')
+parser.add_argument('--output'      , required = True, type = str, help = 'output file name')
+parser.add_argument('--pdf'         , default  = None, type = str, help = 'output pdf directory')
+parser.add_argument('--json'        , required = True, type = str, help = 'output json file name')
+parser.add_argument('--nsplit'      , default  = 5   , type = str, help = 'number of chunks per file')
+parser.add_argument('--pvthreshold' , default  = .05 , type = str, help = 'threshold of KS test (above = ok)')
+
+parser.add_argument('--visual', action = 'store_true', help = 'Won\'t run the script in batch mode')
+parser.add_argument('--legend', action = 'store_true', help = 'Draw a TLegent on canvases')
+args = parser.parse_args()
+
+import os
+if not os.path.exists(args.pdf):
+  os.makedirs(args.pdf)
+
+ROOT.gROOT.SetBatch(not args.visual)
+ROOT.gStyle.SetOptStat(0)
+
+JSON_DICT      = OrderedDict()
+OUTPUT_ROOT    = ROOT.TFile.Open('{}'.format(args.output), 'RECREATE')
+OUTPUT_JSON    = open(args.json, 'w')
+N_SPLITS       = args.nsplit
+PVAL_THRESHOLD = args.pvthreshold
+
+## binning of tested variables (cannot use unbinned distributions with python before root 6.18)
+BINS = {
+  'tau_pt'    : (50, 0, 5000),
+  'tau_eta'   : (5, -2.5, 2.5),
+  'lepton_gen_match' : (20, -1, 19),
+  'sampleType': (20, -1, 19),      
+  'dataset_id': (20, -1, 19),
+  'dataset_group_id': (20, -1, 19),
+}
+
+def groupby(dataframe, by):
+  _ = dataframe.Histo1D(by)
+  hist = _.GetValue()
+  hist.ClearUnderflowAndOverflow()
+  types = list(set([round(hist.GetBinCenter(jj)) for jj in range(hist.GetNbinsX()) if hist.GetBinContent(jj)]))
+
+  return {tt: dataframe.Filter('{} == {}'.format(by, tt)) for tt in types}
+
+def get_histos(dataframe, branch, norm = False):
+  size = int(dataframe.Count())
+  sub_size = 1 + size / N_SPLITS
+  subframes = [dataframe.Range(ii*sub_size, (ii+1)*sub_size) for ii in range(N_SPLITS)]
+  
+  model = (branch, "") + BINS[branch]
+  hptrs = [sf.Histo1D(model, branch) for sf in subframes]
+  histos = [hh.GetValue().Clone() for hh in hptrs]
+  
+  for hh in histos:
+    hh.SetTitle(branch)
+    hh.Sumw2()
+    hh.ClearUnderflowAndOverflow()
+    if norm and hh.Integral():
+      hh.Scale(1. / hh.Integral())
+
+  return histos
+
+def save_histos(histos, fdir, pvalues):
+  OUTPUT_ROOT.cd()
+  OUTPUT_ROOT.cd(fdir)
+  
+  can = ROOT.TCanvas()
+  leg = ROOT.TLegend(0.9, 0.1, 1., 0.9, "p-values (KS with the first chunk)")
+
+  histos[0].GetYaxis().SetRangeUser(0, 1.1*max(hh.GetMaximum() for hh in histos))
+  histos[0].SetMarkerStyle(20)
+
+  for ii, hh in enumerate(histos): 
+    hh.SetLineColor(ii+1)
+    hh.SetMarkerColor(ii+1)
+    leg.AddEntry(hh, 'chunk %d - pval = %.3f' %(ii, pvalues[ii]), 'lep')
+    hh.Draw("PE" + " SAME" * (ii != 0))
+    hh.Write()
+  if args.legend:
+    leg.Draw("SAME")
+  if args.pdf is not None:
+    can.SaveAs('{}/{}.pdf'.format(args.pdf, fdir.replace('/', '_')), 'pdf')
+  can.Write()
+  OUTPUT_ROOT.cd()
+
+def run_validation(dataframe, branches, pwd = ''):
+  OUTPUT_ROOT.cd()
+  OUTPUT_ROOT.mkdir(pwd)
+  
+  if not pwd in JSON_DICT.keys():
+    JSON_DICT[pwd] = OrderedDict()
+
+  for branch in branches:
+    OUTPUT_ROOT.cd() 
+    OUTPUT_ROOT.mkdir('/'.join([pwd, branch]))
+
+    histos = get_histos(dataframe, branch = branch, norm = True)
+  
+    pvalues = [histos[0].KolmogorovTest(hh) if histos[0].Integral()*hh.Integral() else 99 for hh in histos]
+    if not histos[0].Integral():
+      print '[WARNING] control histogram is empty for step {} inside {}'.format(branch, pwd)
+    
+    if not all([pv >= PVAL_THRESHOLD for pv in pvalues]):
+      print '[WARNING] KS test failed for step {} inside {}. p-values are:'.format(branch, pwd)
+      print '\t', pvalues
+    
+    JSON_DICT[pwd][branch] = pvalues
+    
+    save_histos(histos, fdir = '/'.join([pwd, branch]), pvalues = pvalues)
+
+if __name__ == '__main__':
+  print '[INFO] reading files', args.input
+  input_files = ROOT.std.vector('std::string')()
+  for file in glob.glob(args.input):
+    input_files.push_back(str(file))
+
+  main_dir = 'KS_test'
+
+  ## first, run on plain columns
+  dataframe = ROOT.RDataFrame('taus', input_files)
+  run_validation(dataframe = dataframe, pwd = main_dir, branches = ['lepton_gen_match', 'sampleType', 'dataset_group_id'])
+
+  ## then, group by tau type
+  tau_type_dataframes = groupby(dataframe = dataframe, by = 'lepton_gen_match')
+  for ii, df in tau_type_dataframes.iteritems():
+    run_validation(dataframe = df, pwd = '/'.join([main_dir, 'lepton_gen_match', str(ii)]), branches = ['tau_pt', 'tau_eta'])
+
+  ## then, group by sample type
+  sample_type_dataframes = groupby(dataframe = dataframe, by = 'sampleType')
+  for ii, df in sample_type_dataframes.iteritems():
+    run_validation(dataframe = df, pwd = '/'.join([main_dir, 'sampleType', str(ii)]), branches = ['tau_pt', 'tau_eta'])
+
+  ## then, group by dataset group id
+  group_id_dataframes = groupby(dataframe = dataframe, by = 'dataset_group_id')
+  for ii, df in group_id_dataframes.iteritems():
+    run_validation(dataframe = df, pwd = '/'.join([main_dir, 'dataset_group_id', str(ii)]), branches = ['tau_pt', 'tau_eta', 'dataset_id'])
+
+  OUTPUT_ROOT.Close()
+  json.dump(JSON_DICT, OUTPUT_JSON, indent = 4)
+  print '[INFO] all done. Files', args.output, 'and', args.json, 'have been created'

--- a/Production/scripts/validation_tool.py
+++ b/Production/scripts/validation_tool.py
@@ -95,7 +95,7 @@ def save_histos(histos, fdir, pvalues):
   can.Write()
   OUTPUT_ROOT.cd()
 
-def run_validation(dataframe, branches, pwd = ''):
+def run_validation(dataframe, branches, pwd):
   OUTPUT_ROOT.cd()
   OUTPUT_ROOT.mkdir(pwd)
   

--- a/Production/scripts/validation_tool.py
+++ b/Production/scripts/validation_tool.py
@@ -16,7 +16,7 @@ parser.add_argument('--input'       , required = True, type = str, help = 'input
 parser.add_argument('--output'      , required = True, type = str, help = 'output file name')
 parser.add_argument('--pdf'         , default  = None, type = str, help = 'output pdf directory')
 parser.add_argument('--json'        , required = True, type = str, help = 'output json file name')
-parser.add_argument('--nsplit'      , default  = 5   , type = str, help = 'number of chunks per file')
+parser.add_argument('--nsplit'      , default  = 100 , type = str, help = 'number of chunks per file')
 parser.add_argument('--pvthreshold' , default  = .05 , type = str, help = 'threshold of KS test (above = ok)')
 
 parser.add_argument('--visual', action = 'store_true', help = 'Won\'t run the script in batch mode')

--- a/Production/scripts/validation_tool.py
+++ b/Production/scripts/validation_tool.py
@@ -13,9 +13,7 @@ import json
 from collections import OrderedDict
 
 parser.add_argument('--input'       , required = True, type = str, help = 'input file. Accepts glob patterns (use quotes)')
-parser.add_argument('--output'      , required = True, type = str, help = 'output file name')
-parser.add_argument('--pdf'         , default  = None, type = str, help = 'output pdf directory')
-parser.add_argument('--json'        , required = True, type = str, help = 'output json file name')
+parser.add_argument('--output'      , required = True, type = str, help = 'output directory name')
 parser.add_argument('--nsplit'      , default  = 100 , type = str, help = 'number of chunks per file')
 parser.add_argument('--pvthreshold' , default  = .05 , type = str, help = 'threshold of KS test (above = ok)')
 
@@ -24,15 +22,16 @@ parser.add_argument('--legend', action = 'store_true', help = 'Draw a TLegent on
 args = parser.parse_args()
 
 import os
-if not os.path.exists(args.pdf):
-  os.makedirs(args.pdf)
+pdf_dir = '/'.join([args.output, 'pdf'])
+if not os.path.exists(pdf_dir):
+  os.makedirs(pdf_dir)
 
 ROOT.gROOT.SetBatch(not args.visual)
 ROOT.gStyle.SetOptStat(0)
 
 JSON_DICT      = OrderedDict()
-OUTPUT_ROOT    = ROOT.TFile.Open('{}'.format(args.output), 'RECREATE')
-OUTPUT_JSON    = open(args.json, 'w')
+OUTPUT_ROOT    = ROOT.TFile.Open('{}/histograms.root'.format(args.output), 'RECREATE')
+OUTPUT_JSON    = open('{}/pvalues.json'.format(args.output), 'w')
 N_SPLITS       = args.nsplit
 PVAL_THRESHOLD = args.pvthreshold
 
@@ -92,8 +91,7 @@ def save_histos(histos, fdir, pvalues):
     hh.Write()
   if args.legend:
     leg.Draw("SAME")
-  if args.pdf is not None:
-    can.SaveAs('{}/{}.pdf'.format(args.pdf, fdir.replace('/', '_')), 'pdf')
+  can.SaveAs('{}/pdf/{}.pdf'.format(args.output, fdir.replace('/', '_')), 'pdf')
   can.Write()
   OUTPUT_ROOT.cd()
 

--- a/Production/scripts/validation_tool.py
+++ b/Production/scripts/validation_tool.py
@@ -3,6 +3,7 @@ import argparse
 parser = argparse.ArgumentParser('''
 The script runs a binned KS test between different chunks of the same RDataFrame. For simplicity, all chunks are compared to the first one.
 If a KS test is below the threshold, a warning message is printed on screen.
+NOTE: the binning of each variable must be hard coded in the script (using the BINS dictionary)
 NOTE: pvalue = 99 means that one of the two histograms is empty.
 ''')
 
@@ -106,7 +107,7 @@ def run_validation(dataframe, branches, pwd = ''):
     OUTPUT_ROOT.mkdir('/'.join([pwd, branch]))
 
     histos = get_histos(dataframe, branch = branch, norm = True)
-  
+
     pvalues = [histos[0].KolmogorovTest(hh) if histos[0].Integral()*hh.Integral() else 99 for hh in histos]
     if not histos[0].Integral():
       print '[WARNING] control histogram is empty for step {} inside {}'.format(branch, pwd)

--- a/README.md
+++ b/README.md
@@ -161,6 +161,35 @@ ShuffleMerge --cfg TauML/Analysis/config/testing_inputs.cfg --input tuples-v2 --
              --n-threads 12 --disabled-branches "trainingWeight"
 ```
 
+#### Validation
+A validation can be run on shuffled samples to ensure that different parts of the training set have compatible distributions.
+To run the validation tool, a ROOT version greater or equal to 6.16 is needed:
+```
+source /cvmfs/sft.cern.ch/lcg/views/LCG_97apython3/x86_64-centos7-clang10-opt/setup.sh
+```
+Then, run:
+```
+python TauMLTools/Production/scripts/validation_tool.py  --input "/path/to/input/*.root" \
+                                                         --output output_directory \
+                                                         --n_threads n_threads \
+                                                         --legend > results.txt
+```
+The script will create the directory "output_directory" containing the results of the test.
+Validation is run on the following ditributions with a Kolmogorov-Smirnov test:
+
+- dataset_id, dataset_group_id, lepton_gen_match, sampleType 
+- tau_pt and tau_eta for each bin of the previous
+- dataset_id for each bin of dataset_group_id
+
+If a KS test is not successful, a warning message is print on screen.
+
+Optional arguments are available running:
+```
+python TauMLTools/Production/scripts/validation_tool.py --help
+```
+
+A time benchmark is available [here](https://github.com/cms-tau-pog/TauMLTools/pull/31#issue-510206277).
+
 ### Production of flat inputs
 
 In this stage, `TauTuple`s are transformed into flat [TrainingTuples](https://github.com/cms-tau-pog/TauMLTools/blob/master/Analysis/interface/TrainingTuple.h) that are suitable as an input for the training.


### PR DESCRIPTION
PR to add the vaidation tool. The script loads a list of files into a RDataFrame, splits the dataframe into different chunks and then runs a Kolmogorov-Smirnov test between the first chunk and the rest to check the compatibility of some distributions.

The distributions considered for the KS test are:
- lepton_gen_match, and:
  - tau_pt and tau_eta for each gen match value
- sample_type distribution, and:
  - tau_pt and tau_eta for each sample type value
- dataset_group_id distribution, and:
  - tau_pt, tau_eta for each group id value
  - dataset_id for each group id value

The script creates a root file storing the chunk histograms, a json file with the p-values and the pdf files of the KS comparison. 
You can find and example at /afs/cern.ch/user/l/lguzzi/public/TauPOG/validation_tool_test (run on /eos/cms/store/group/phys_tau/TauML/prod_2018_v1/full_tuples/WJetsToLNu_HT-2500ToInf/eventTuple_1-1.root)

### Time tests
Here are some timing test I run on an lxplus machine:
- root-version: 6.20/02
- dataset: WJetsToLNu_HT-1200To2500
  - size: 42 GB
  - events: 15890103 (15 milion)

```
source /cvmfs/sft.cern.ch/lcg/views/LCG_97apython3/x86_64-centos7-clang10-opt/setup.sh
python -m cProfile validation_tool.py --input "/eos/cms/store/group/phys_tau/TauML/prod_2018_v1/full_tuples/WJetsToLNu_HT-1200To2500/*.root" --output test-v5 --legend
```
Run time after a fresh login (subsequent calls are about twice as fast):
1 thread: 106 s
4 thread: 47 s
10 thread:  19 s

The most time consuming function is load_histograms, which takes about 7s per call running on one thread, 2s per call  running on four threads and 1s per call on ten threads (13 calls in total).






