### PR TITLE
update validation tool

### DIFF
--- a/Production/scripts/validation_tool.py
+++ b/Production/scripts/validation_tool.py
@@ -42,7 +42,7 @@ PVAL_THRESHOLD = args.pvthreshold
 BINS = {
   'tau_pt'    : (50, 0, 5000),
   'tau_eta'   : (5, -3.2, 3.2),
-  'tauType' : (4, 0, 4),
+  'tauType' : (10, 0, 10),
   'sampleType': (20, -1, 19),
 }
 

--- a/Production/scripts/validation_tool.py
+++ b/Production/scripts/validation_tool.py
@@ -1,9 +1,9 @@
 from __future__ import print_function
 
 import ROOT
-import glob
 import json
 from collections import OrderedDict
+import os
 
 import argparse
 parser = argparse.ArgumentParser('''
@@ -13,7 +13,7 @@ NOTE: the binning of each variable must be hard coded in the script (using the B
 NOTE: pvalue = 99 means that one of the two histograms is empty.
 ''')
 
-parser.add_argument('--input'         , required = True, type = str, help = 'input file. Accepts glob patterns (use quotes)')
+parser.add_argument('--input'         , required = True, type = str, help = 'input directory. Will loop inside all subdirectories')
 parser.add_argument('--output'        , required = True, type = str, help = 'output directory name')
 parser.add_argument('--nsplit'        , default  = 100 , type = int, help = 'number of chunks per file')
 parser.add_argument('--pvthreshold'   , default  = .05 , type = str, help = 'threshold of KS test (above = ok)')
@@ -28,7 +28,6 @@ args = parser.parse_args()
 ROOT.gROOT.SetBatch(not args.visual)
 ROOT.gStyle.SetOptStat(0)
 
-import os
 pdf_dir = '/'.join([args.output, 'pdf'])
 if not os.path.exists(pdf_dir):
   os.makedirs(pdf_dir)
@@ -125,8 +124,10 @@ if __name__ == '__main__':
 
   input_files = ROOT.std.vector('std::string')()
   
-  for file in glob.glob(args.input):
-    input_files.push_back(str(file))
+  for root, dirs, files in os.walk(args.input):
+    for ff in files:
+      if not '.root' in ff: continue
+      input_files.push_back('/'.join([root, ff]))
 
   model = lambda main, third = None: (main, '', N_SPLIT, 0, N_SPLIT)+BINS[main]+BINS[third] if not third is None else (main, '', N_SPLIT, 0, N_SPLIT)+BINS[main]
   

--- a/Production/scripts/validation_tool.py
+++ b/Production/scripts/validation_tool.py
@@ -38,14 +38,12 @@ OUTPUT_JSON    = open('{}/pvalues.json'.format(args.output), 'w')
 N_SPLIT        = args.nsplit
 PVAL_THRESHOLD = args.pvthreshold
 
-## binning of tested variables
+## binning of tested variables (dataset group id and dataset id are guessed from jsons)
 BINS = {
   'tau_pt'    : (50, 0, 5000),
   'tau_eta'   : (5, -3.2, 3.2),
-  'TauType' : (20, -1, 19),
-  'sampleType': (20, -1, 19),      
-  'dataset_id': (20, -1, 19),
-  'dataset_group_id': (20, -1, 19),
+  'tauType' : (4, 0, 4),
+  'sampleType': (20, -1, 19),
 }
 
 class Lazy_container:
@@ -117,7 +115,7 @@ def to_2D(histo, vbin):
   return histo.Project3D('yx').Clone()
 
 if __name__ == '__main__':
-  print ('[INFO] reading files', args.input)
+  print ('[INFO] reading files from', args.input)
   
   if args.n_threads > 1:
     ROOT.ROOT.EnableImplicitMT(args.n_threads)
@@ -154,7 +152,7 @@ for(std::vector<int>::iterator it = hash_list.begin(); it != hash_list.end(); it
   dataframe = dataframe.Define('uh_dataset_group_id', cpp_function % (','.join(group_ids), 'dataset_group_id'))
 
   ## unbinned distributions
-  ptr_lgm = Lazy_container(dataframe.Histo2D(model('TauType'), 'chunk_id', 'TauType'))
+  ptr_lgm = Lazy_container(dataframe.Histo2D(model('tauType'), 'chunk_id', 'tauType'))
   ptr_st  = Lazy_container(dataframe.Histo2D(model('sampleType')      , 'chunk_id', 'sampleType'      ))
   ptr_dgi = Lazy_container(dataframe.Histo2D(model('uh_dataset_group_id'), 'chunk_id', 'uh_dataset_group_id'))
   ptr_di  = Lazy_container(dataframe.Histo2D(model('uh_dataset_id')      , 'chunk_id', 'uh_dataset_id'      ))

--- a/Production/scripts/validation_tool.py
+++ b/Production/scripts/validation_tool.py
@@ -41,7 +41,7 @@ PVAL_THRESHOLD = args.pvthreshold
 BINS = {
   'tau_pt'    : (50, 0, 5000),
   'tau_eta'   : (5, -3.2, 3.2),
-  'lepton_gen_match' : (20, -1, 19),
+  'TauType' : (20, -1, 19),
   'sampleType': (20, -1, 19),      
   'dataset_id': (20, -1, 19),
   'dataset_group_id': (20, -1, 19),
@@ -133,7 +133,7 @@ if __name__ == '__main__':
   dataframe = dataframe.Define('chunk_id', 'rdfentry_ * {} / {}'.format(N_SPLIT, tot_entries))
 
   ## unbinned distributions
-  ptr_lgm = Lazy_container(dataframe.Histo2D(model('lepton_gen_match'), 'chunk_id', 'lepton_gen_match'))
+  ptr_lgm = Lazy_container(dataframe.Histo2D(model('TauType'), 'chunk_id', 'TauType'))
   ptr_st  = Lazy_container(dataframe.Histo2D(model('sampleType')      , 'chunk_id', 'sampleType'      ))
   ptr_dgi = Lazy_container(dataframe.Histo2D(model('dataset_group_id'), 'chunk_id', 'dataset_group_id'))
   ptr_di  = Lazy_container(dataframe.Histo2D(model('dataset_id')      , 'chunk_id', 'dataset_id'      ))
@@ -141,11 +141,11 @@ if __name__ == '__main__':
   ## binned distributions
   ptrs_tau_pt = {
     binned_variable: Lazy_container(dataframe.Histo3D(model('tau_pt', third = binned_variable), 'chunk_id', 'tau_pt', binned_variable))
-      for binned_variable in ['lepton_gen_match', 'sampleType', 'dataset_group_id', 'dataset_id']
+      for binned_variable in ['TauType', 'sampleType', 'dataset_group_id', 'dataset_id']
   }
   ptrs_tau_eta = {
     binned_variable: Lazy_container(dataframe.Histo3D(model('tau_eta', third = binned_variable), 'chunk_id', 'tau_eta', binned_variable))
-      for binned_variable in ['lepton_gen_match', 'sampleType', 'dataset_group_id', 'dataset_id']
+      for binned_variable in ['TauType', 'sampleType', 'dataset_group_id', 'dataset_id']
   }
   ptrs_dataset_id = {
     binned_variable: Lazy_container(dataframe.Histo3D(model('dataset_id', third = binned_variable), 'chunk_id', 'dataset_id', binned_variable))
@@ -161,20 +161,20 @@ if __name__ == '__main__':
     lc.load_histogram()
   
   ## run validation
-  entry_lgm = Entry(var = 'lepton_gen_match', histo = ptr_lgm.hst)
+  entry_lgm = Entry(var = 'TauType', histo = ptr_lgm.hst)
   entry_st  = Entry(var = 'sampleType'      , histo = ptr_st .hst)
   entry_dgi = Entry(var = 'dataset_group_id', histo = ptr_dgi.hst)
   entry_di  = Entry(var = 'dataset_id'      , histo = ptr_di .hst)
 
   entries_tau_pt = [
     Entry(var = 'tau_pt', histo = to_2D(ptrs_tau_pt[binned_variable].hst, jj+1), tdir = '/'.join([binned_variable, str(bb), 'tau_pt']))
-      for binned_variable in ['lepton_gen_match', 'sampleType', 'dataset_group_id', 'dataset_id']
+      for binned_variable in ['TauType', 'sampleType', 'dataset_group_id', 'dataset_id']
       for jj, bb in enumerate(range(*BINS[binned_variable][1:]))
   ] ; entries_tau_pt = [ee for ee in entries_tau_pt if ee.hst.GetEntries()]
 
   entries_tau_eta = [
     Entry(var = 'tau_eta', histo = to_2D(ptrs_tau_eta[binned_variable].hst, jj+1), tdir = '/'.join([binned_variable, str(bb), 'tau_eta']))
-      for binned_variable in ['lepton_gen_match', 'sampleType', 'dataset_group_id', 'dataset_id']
+      for binned_variable in ['TauType', 'sampleType', 'dataset_group_id', 'dataset_id']
       for jj, bb in enumerate(range(*BINS[binned_variable][1:]))
   ] ; entries_tau_eta = [ee for ee in entries_tau_eta if ee.hst.GetEntries()]
   

--- a/Production/scripts/validation_tool.py
+++ b/Production/scripts/validation_tool.py
@@ -4,6 +4,7 @@ import ROOT
 import json
 from collections import OrderedDict
 import os
+import re
 
 import argparse
 parser = argparse.ArgumentParser('''
@@ -14,6 +15,7 @@ NOTE: pvalue = 99 means that one of the two histograms is empty.
 ''')
 
 parser.add_argument('--input'         , required = True, type = str, help = 'input directory. Will loop inside all subdirectories')
+parser.add_argument('--regex'  , default  = '.*\.root$', type = str, help = 'regular expression to match to input files')
 parser.add_argument('--output'        , required = True, type = str, help = 'output directory name')
 parser.add_argument('--nsplit'        , default  = 100 , type = int, help = 'number of chunks per file')
 parser.add_argument('--pvthreshold'   , default  = .05 , type = str, help = 'threshold of KS test (above = ok)')
@@ -121,11 +123,11 @@ if __name__ == '__main__':
     ROOT.ROOT.EnableImplicitMT(args.n_threads)
 
   input_files = ROOT.std.vector('std::string')()
+  file_list = ['/'.join([root, ff]) for root, dirs, files in os.walk(args.input) for ff in files]
+  file_list = sorted([ff for ff in file_list if not re.match(args.regex, ff) is None])
   
-  for root, dirs, files in os.walk(args.input):
-    for ff in files:
-      if not '.root' in ff: continue
-      input_files.push_back('/'.join([root, ff]))
+  for ff in file_list:
+    input_files.push_back(ff)
 
   model = lambda main, third = None: (main, '', N_SPLIT, 0, N_SPLIT)+BINS[main]+BINS[third] if not third is None else (main, '', N_SPLIT, 0, N_SPLIT)+BINS[main]
   

--- a/README.md
+++ b/README.md
@@ -169,11 +169,14 @@ source /cvmfs/sft.cern.ch/lcg/views/LCG_97apython3/x86_64-centos7-clang10-opt/se
 ```
 Then, run:
 ```
-python TauMLTools/Production/scripts/validation_tool.py  --input "/path/to/input/*.root" \
+python TauMLTools/Production/scripts/validation_tool.py  --input input_directory \
+                                                         --id_json /path/to/dataset_id_json_file \
+                                                         --group_id_json /path/to/dataset_group_id_json_file \
                                                          --output output_directory \
                                                          --n_threads n_threads \
                                                          --legend > results.txt
 ```
+The *id_json*  (*group_id_json*) points to a json file containing the list of datasets names (dataset group names) and their hash values, used to identify them inside the shuffled ROOT tuples. These files are needed in order to create a unique identifier which can be handled by ROOT. These files are produced at the shuffle and merge step. 
 The script will create the directory "output_directory" containing the results of the test.
 Validation is run on the following ditributions with a Kolmogorov-Smirnov test:
 


### PR DESCRIPTION
Updating validation tool:

- now the input is a directory and all '*.root' files inside that directory and all of its subdirectories are considered (using os.walk module)
- the lepton_gen_match variable has been changed to tauType
- now can handle hashed dataset group and dataset ids (two additional arguments added: path to the dataset group and dataset id json files)
-updated readme

tested running:
```
 python TauMLTools/Production/scripts/validation_tool.py  --input /afs/cern.ch/work/m/myshched/public/shuffle/ --output test-dir_2 --n_threads 10  --legend --id_json /afs/cern.ch/work/m/myshched/public/shuffle/dataset_hash.json --group_id_json /afs/cern.ch/work/m/myshched/public/shuffle/datagroup_hash.json --nsplit 5
```