### PR TITLE
Shuffle&Merge (RAM problem)

### DIFF
--- a/Analysis/bin/ShuffleMergeSpectral.cxx
+++ b/Analysis/bin/ShuffleMergeSpectral.cxx
@@ -86,10 +86,11 @@ struct SourceDesc {
                 current_file_index = 0;
             else
                 ++(*current_file_index);
-            if(*current_file_index >= file_names.size())
-                throw exception("The expected number of events = %1% is bigger than the actual number of"
-                                          " end point events in source '%2%'.") % entries_file % name;
-
+            if(current_file_index == files_n_total) {
+              std::cerr << "WARNING: The current file index = " << current_file_index
+                        << " is bigger than the actual number of files" << std::endl;
+              return false;
+            }
             const std::string& file_name = file_names.at(*current_file_index);
             std::cout << "Opening: " << name << " " << file_name << std::endl;
             dataset_hash = dataset_hash_arr.at(*current_file_index);
@@ -103,6 +104,9 @@ struct SourceDesc {
 
             if(!entries_file)
               throw exception("Root file %1% is empty.") % file_name;
+            if(entries_end-current_n_processed==0)
+              std::cerr << "WARNING: The reading ranges are small, no entries are taken. "
+                        << "Dataset hash: " << dataset_hash << " Data group: " << name << std::endl;
         }
         current_tuple->GetEntry(current_n_processed++);
         const auto gen_match = static_cast<GenLeptonMatch>((*current_tuple)().lepton_gen_match);

--- a/Analysis/bin/ShuffleMergeSpectral.cxx
+++ b/Analysis/bin/ShuffleMergeSpectral.cxx
@@ -87,7 +87,7 @@ struct SourceDesc {
             else
                 ++(*current_file_index);
             if(current_file_index == files_n_total) {
-              std::cerr << "WARNING: The current file index = " << current_file_index
+              std::cout << "WARNING: The current file index = " << current_file_index
                         << " is bigger than the actual number of files" << std::endl;
               return false;
             }
@@ -95,7 +95,6 @@ struct SourceDesc {
             std::cout << "Opening: " << name << " " << file_name << std::endl;
             dataset_hash = dataset_hash_arr.at(*current_file_index);
             current_tuple.reset();
-            if(current_file) current_file->Close();
             current_file = root_ext::OpenRootFile(file_name);
             current_tuple = std::make_shared<TauTuple>("taus", current_file.get(), true, disabled_branches);
             entries_file = current_tuple->GetEntries();
@@ -105,7 +104,7 @@ struct SourceDesc {
             if(!entries_file)
               throw exception("Root file %1% is empty.") % file_name;
             if(entries_end-current_n_processed==0)
-              std::cerr << "WARNING: The reading ranges are small, no entries are taken. "
+              std::cout << "WARNING: The reading ranges are small, no entries are taken. "
                         << "Dataset hash: " << dataset_hash << " Data group: " << name << std::endl;
         }
         current_tuple->GetEntry(current_n_processed++);

--- a/Core/interface/SmartTree.h
+++ b/Core/interface/SmartTree.h
@@ -190,7 +190,7 @@ public:
         : name(_name), directory(_directory), readMode(_readMode), disabled_branches(_disabled_branches),
           enabled_branches(_enabled_branches)
     {
-        static constexpr Long64_t maxVirtualSize = 200 * 1024 * 1024;
+        static constexpr Long64_t maxVirtualSize = 100 * 1024 * 1024;
         static constexpr Long64_t autoFlush = - 50 * 1024 * 1024;
         static constexpr Long64_t maxTreeSize = 1000000000000LL;
 
@@ -198,6 +198,7 @@ public:
             if(!directory)
                 throw std::runtime_error("Can't read tree from nonexistent directory.");
             tree = dynamic_cast<TTree*>(directory->Get(name.c_str()));
+            // tree->SetMaxVirtualSize(maxVirtualSize);
             if(!tree)
                 throw std::runtime_error("Tree not found.");
             if(tree->GetNbranches())

--- a/Core/interface/SmartTree.h
+++ b/Core/interface/SmartTree.h
@@ -190,15 +190,15 @@ public:
         : name(_name), directory(_directory), readMode(_readMode), disabled_branches(_disabled_branches),
           enabled_branches(_enabled_branches)
     {
-        static constexpr Long64_t maxVirtualSize = 100 * 1024 * 1024;
-        static constexpr Long64_t autoFlush = - 50 * 1024 * 1024;
+      static constexpr Long64_t maxVirtualSize = 10 * 1024 * 1024;
+        static constexpr Long64_t autoFlush = - 10 * 1024 * 1024;
         static constexpr Long64_t maxTreeSize = 1000000000000LL;
 
         if(readMode) {
             if(!directory)
                 throw std::runtime_error("Can't read tree from nonexistent directory.");
             tree = dynamic_cast<TTree*>(directory->Get(name.c_str()));
-            // tree->SetMaxVirtualSize(maxVirtualSize);
+            tree->SetMaxVirtualSize(maxVirtualSize);
             if(!tree)
                 throw std::runtime_error("Tree not found.");
             if(tree->GetNbranches())

--- a/Core/interface/SmartTree.h
+++ b/Core/interface/SmartTree.h
@@ -190,8 +190,8 @@ public:
         : name(_name), directory(_directory), readMode(_readMode), disabled_branches(_disabled_branches),
           enabled_branches(_enabled_branches)
     {
-      static constexpr Long64_t maxVirtualSize = 10 * 1024 * 1024;
-        static constexpr Long64_t autoFlush = - 10 * 1024 * 1024;
+        static constexpr Long64_t maxVirtualSize = 100 * 1024 * 1024;
+        static constexpr Long64_t autoFlush = - 50 * 1024 * 1024;
         static constexpr Long64_t maxTreeSize = 1000000000000LL;
 
         if(readMode) {


### PR DESCRIPTION
With this fixes RAM usage is within the 5-5.5 Gb (require 6000Mb when running with Law), and error is removed. This branch can be tested on law.

The tests were preformed with the following command: `law run ShuffleMergeSpectral --version flush10_virt10 --cfg $CMSSW_BASE/src/TauMLTools/Analysis/config/2018/training_inputs_MC.cfg --input-path /eos/cms/store/group/phys_tau/TauML/prod_2018_v1/full_tuples --output-path /eos/user/m/myshched/LawTest_flush10_virt10 --mode MergeAll --input-spec /afs/cern.ch/work/m/myshched/public/root-tuple-v2-hists --pt-bins "20, 30, 40, 50, 60, 70, 80, 90, 100, 1000" --eta-bins "0., 0.6, 1.2, 1.8, 2.4" --tau-ratio "jet:1, e:1, mu:1, tau:1, emb_tau:-1, emb_jet:-1" --n-jobs 500 --disabled-branches "trainingWeight, tauType" --max-memory 6000 --max-runtime 24`
Among 500 jobs, ~14 was failed with:
1. TFile reading error or
2. basket's WriteBuffer failed
3. ERROR: SmartTree: the object cannot be written.
But in case of reading error, the files, where this error occurred were perfectly read by other jobs, so I guess resubmission would help. For the moment I can not reproduce them.

Among ~110 jobs were finished successfully and their files are readable (~500Mb each), the rest were removed due to the --max-runtime 24 limits (but they are recoverable, and I also can read this files), I estimate time within 26-27 hours limit, so --max-runtime 30 should do the business and finish first version of Shuffled and Merged files (or 40h for safety). The requirements I hope can be minimized after re-organizing and merging our tuples with `hadd -O -ff`. Right now my dataset is 155GB

Here is the list of what else is required in ShuffleMergeSpectral.cxx (not to forget):
- interface to set physics spectrum as target one
- remove `&` for the simple types
- when any of tau types in dataset is not present in `--tau-ratio "jet:1, e:1, mu:1, tau:1"` the following error rises `error map at()` this error needs to be handled with the user-readable message.