### PR TITLE
Update ShuffleMergeSpectral.cxx to read input from a file list

### DIFF
--- a/Analysis/bin/ShuffleMergeSpectral.cxx
+++ b/Analysis/bin/ShuffleMergeSpectral.cxx
@@ -27,7 +27,10 @@ ENUM_NAMES(MergeMode) = {
 
 struct Arguments {
     run::Argument<std::string> cfg{"cfg", "configuration file with the list of input sources"};
-    run::Argument<std::string> input{"input", "input path with tuples for all the samples"};
+    run::Argument<std::string> input{"input", "Input file with the list of files to read. "
+                                              "The --prefix argument will be placed in front of --input.", ""};
+    run::Argument<std::string> prefix{"prefix", "Prefix to place before the input file path read from --input. "
+                                                "It can include a remote server to use with xrootd.", ""};
     run::Argument<std::string> output{"output", "output, depending on the merging mode: MergeAll - file,"
                                                 " MergePerEntry - directory."};
     run::Argument<std::string> pt_bins{"pt-bins", "pt bins (last bin will be chosen as high-pt region, \
@@ -159,7 +162,6 @@ struct SourceDesc {
     Generator* gen;
   };
 
-
 struct EntryDesc {
 
     std::string name;
@@ -167,69 +169,75 @@ struct EntryDesc {
     std::vector<std::string> data_files;
     std::vector<std::string> data_set_names;
     std::vector<ULong64_t> data_set_names_hashes;
-    std::vector<std::string> spectrum_files;
+    std::set<std::string> spectrum_files;
     std::set<TauType> tau_types;
 
     EntryDesc(const PropertyConfigReader::Item& item,
-              const std::string& base_input_dir,
-              const std::string& base_spectrum_dir)
+              const std::string& base_spectrum_dir,
+              const std::string& input_paths,
+              const std::string& prefix)
     {
         using boost::regex;
         using boost::regex_match;
-        using boost::filesystem::path;
-        using boost::make_iterator_range;
-        using boost::filesystem::directory_iterator;
-        using boost::filesystem::is_directory;
-        using boost::filesystem::is_regular_file;
-        using boost::split;
 
         name = item.name;
         name_hash = std::hash<std::string>{}(name);
-        std::cout << name << std::endl;
-        const std::string dir_pattern_str = item.Get<std::string>("dir");
+
+        const std::string dir_pattern_str  = item.Get<std::string>("dir");
         const std::string file_pattern_str = item.Get<std::string>("file");
-        const std::string tau_types_str = item.Get<std::string>("types");
+        const std::string tau_types_str    = item.Get<std::string>("types");
+
+        const regex dir_pattern (dir_pattern_str );
+        const regex file_pattern(file_pattern_str);
+
         tau_types = SplitValueListT<TauType, std::set<TauType>>(tau_types_str, false, ",");
 
-        const path base_input_path(base_input_dir);
-        if(!is_directory(base_input_dir))
-          throw exception("The base directory '%1%' (--input) does not exists.") % base_input_dir;
-        const regex dir_pattern(base_input_dir + "/" + dir_pattern_str); // Patern for Big root-tuples
-        bool has_dir_match = false;
-
-        for(const auto& sample_dir_entry : make_iterator_range(directory_iterator(base_input_path))) {
-          if(!is_directory(sample_dir_entry) || !regex_match(sample_dir_entry.path().string(), dir_pattern)) continue;
-
-          std::cout << sample_dir_entry << " - dataset" << std::endl;
-          const std::string dir_name = sample_dir_entry.path().filename().string();
-          const path spectrum_file(base_spectrum_dir + "/" + dir_name + ".root");
-
-          if(!is_regular_file(spectrum_file))
-            throw exception("No spectrum file are founupperd for entry '%1%'") % sample_dir_entry;
-          std::cout << spectrum_file << " - spectrum" << std::endl;
-
-          has_dir_match = true;
-
-          const regex file_pattern(sample_dir_entry.path().string() + "/" + file_pattern_str + ".root");
-          bool has_file_match = false;
-          for(const auto& file_entry : make_iterator_range(directory_iterator(sample_dir_entry.path()))) {
-            if(is_directory(file_entry) || !regex_match(file_entry.path().string(), file_pattern)) continue;
-            has_file_match = true;
-            const std::string file_name = file_entry.path().string();
-            data_files.push_back(file_name);
-            data_set_names.push_back(dir_name);
-            data_set_names_hashes.push_back(std::hash<std::string>{}(dir_name));
-          }
-          spectrum_files.push_back(spectrum_file.string());
-
-          if(!has_file_match)
-            throw exception("No files are found for entry '%1%' sample %2% with pattern '%3%'")
-              % name % sample_dir_entry % file_pattern_str;
+        std::ifstream input_files (input_paths, std::ifstream::in);
+        if (!input_files){
+          throw exception("The input file %1% could not be opened")
+            %input_paths;
         }
 
-        if(!has_dir_match)
-            throw exception("No samples are found for entry '%1%' with pattern '%2%'")
-                  % name % dir_pattern_str;
+        bool is_matching = false;
+
+        std::string ifile;
+        std::string dir_name, file_name, spectrum_file, file_path;
+        while(std::getline(input_files, ifile)){
+          dir_name  = ifile.substr(0, ifile.rfind("/"));
+          file_name = ifile.substr(ifile.rfind("/")+1, ifile.length());
+
+          // remove "./" and the trailing "/" only from the dataset name, leave the file path unchanged
+          if (dir_name[0] == '.' && dir_name[1] == '/'){
+              dir_name.erase(0, 2);
+          }
+          if (dir_name[dir_name.length()-1] == '/'){
+            dir_name.pop_back();
+          }
+
+          if(!regex_match(dir_name , dir_pattern )) continue;
+          if(!regex_match(file_name, file_pattern)) continue;
+
+          is_matching = true;
+
+          spectrum_file = base_spectrum_dir + "/" + dir_name + ".root";
+
+          file_path = prefix + "/" + ifile;
+
+          data_files.push_back(file_path);
+          data_set_names.push_back(dir_name);
+          data_set_names_hashes.push_back(std::hash<std::string>{}(dir_name));
+          spectrum_files.insert(spectrum_file);
+        }
+
+        if(!is_matching){
+          throw exception("No files are found for entry '%1%' with pattern '%2%'")
+              % name % file_pattern_str;
+        }
+
+        std::cout << name << std::endl;
+        for (const auto spectrum_file : spectrum_files){
+          std::cout << spectrum_file << " - spectrum" << std::endl;
+        }
     }
 };
 
@@ -674,7 +682,7 @@ private:
         std::cout << cfg_file_name << std::endl;
         reader.Parse(cfg_file_name);
         for(const auto& item : reader.GetItems()){
-            entries.emplace_back(item.second, args.input(), args.path_spectrum());
+            entries.emplace_back(item.second,  args.path_spectrum(), args.input(), args.prefix());
         }
         return entries;
     }

--- a/Analysis/bin/ShuffleMergeSpectral.cxx
+++ b/Analysis/bin/ShuffleMergeSpectral.cxx
@@ -208,10 +208,10 @@ struct EntryDesc {
           file_name = ifile.substr(ifile.rfind("/")+1, ifile.length());
 
           // remove "./" and the trailing "/" only from the dataset name, leave the file path unchanged
-          if (dir_name[0] == '.' && dir_name[1] == '/'){
+          if (dir_name.length() >= 2 && dir_name[0] == '.' && dir_name[1] == '/'){
               dir_name.erase(0, 2);
           }
-          if (dir_name[dir_name.length()-1] == '/'){
+          if (dir_name.length() > 0 && dir_name[dir_name.length()-1] == '/'){
             dir_name.pop_back();
           }
 

--- a/Analysis/bin/ShuffleMergeSpectral.cxx
+++ b/Analysis/bin/ShuffleMergeSpectral.cxx
@@ -33,8 +33,8 @@ struct Arguments {
                                                 "It can include a remote server to use with xrootd.", ""};
     run::Argument<std::string> output{"output", "output, depending on the merging mode: MergeAll - file,"
                                                 " MergePerEntry - directory."};
-    run::Argument<std::string> pt_bins{"pt-bins", "pt bins (last bin will be chosen as high-pt region, \
-                                                   lower pt edgeof the last bin will be choosen as pt_threshold)"};
+    run::Argument<std::string> pt_bins{"pt-bins", "pt bins (last bin will be chosen as high-pt region, "
+                                                  "lower pt edgeof the last bin will be choosen as pt_threshold)"};
     run::Argument<std::string> eta_bins{"eta-bins", "eta bins"};
     run::Argument<MergeMode> mode{"mode", "merging mode: MergeAll or MergePerEntry"};
     run::Argument<size_t> max_entries{"max-entries", "maximal number of entries in output train+test tuples",
@@ -43,9 +43,10 @@ struct Arguments {
     run::Argument<unsigned> seed{"seed", "random seed to initialize the generator used for sampling", 1234567};
     run::Argument<std::string> disabled_branches{"disabled-branches",
                                                  "list of branches to disabled in the input tuples", ""};
-    run::Argument<std::string> path_spectrum{"input-spec", "input path with spectrums for all the samples"};
-    run::Argument<std::string> tau_ratio{"tau-ratio", "ratio of tau types in the final spectrum \
-                                                      (if to take all taus of type e => e:-1 )"};
+    run::Argument<std::string> path_spectrum{"input-spec", "input path with spectrums for all the samples. "
+                                                           "A remote server can be specified to use with xrootd."};
+    run::Argument<std::string> tau_ratio{"tau-ratio", "ratio of tau types in the final spectrum "
+                                                      "(if to take all taus of type e => e:-1 )"};
     run::Argument<double> start_entry{"start-entry", "starting ratio from which file will be processed", 0};
     run::Argument<double> end_entry{"end-entry", "end ratio until which file will be processed", 1};
     run::Argument<double> exp_disbalance{"exp-disbalance", "maximal expected disbalance between low pt and high pt regions",0};

--- a/Analysis/law/ShuffleMergeSpectral/tasks.py
+++ b/Analysis/law/ShuffleMergeSpectral/tasks.py
@@ -96,8 +96,8 @@ class ShuffleMergeSpectral(Task, HTCondorWorkflow, law.LocalWorkflow):
     if retcode != 0:
       raise Exception('job {} return code is {}'.format(self.branch, retcode))
     elif retcode == 0 and self.mode == 'MergeAll':
-      shutil.move(output_name, '/'.join([self.output_dir, '..', file_name]))
-      shutil.move('./out', '/'.join([self.output_dir, '..', 'hashes', 'out_{}'.format(self.branch)]))
+      shutil.move(output_name, os.path.abspath('/'.join([self.output_dir, '..', file_name])))
+      shutil.move('./out', os.path.abspath('/'.join([self.output_dir, '..', 'hashes', 'out_{}'.format(self.branch)])))
       taskout = self.output()
       taskout.dump('Task ended with code %s\n' %retcode)
     else:

--- a/Analysis/law/ShuffleMergeSpectral/tasks.py
+++ b/Analysis/law/ShuffleMergeSpectral/tasks.py
@@ -14,7 +14,8 @@ import luigi
 class ShuffleMergeSpectral(Task, HTCondorWorkflow, law.LocalWorkflow):
   ## '_' will be converted to '-' for the shell command invocation
   cfg               = luigi.Parameter(description = 'configuration file with the list of input sources')
-  input_path        = luigi.Parameter(description = 'input path with tuples for all the samples')
+  input_path        = luigi.Parameter(description = 'Input file with the list of files to read. '
+                                                    'The --prefix argument will be placed in front of --input.')
   output_path       = luigi.Parameter(description = 'output directory')
   pt_bins           = luigi.Parameter(description = 'pt bins')
   eta_bins          = luigi.Parameter(description = 'eta bins')
@@ -22,7 +23,9 @@ class ShuffleMergeSpectral(Task, HTCondorWorkflow, law.LocalWorkflow):
   input_spec        = luigi.Parameter(description = '')
   tau_ratio         = luigi.Parameter(description = '')
   n_jobs            = luigi.IntParameter(description = 'number of HTCondor jobs to run')
-  ## optional arguments (default will be None: don't override ShuffleMergeSpectral.cxx default values)
+  ## optional arguments (default will be an empty string: don't override ShuffleMergeSpectral.cxx default values)
+  prefix            = luigi.Parameter(description = 'Prefix to place before the input file path read from --input.'
+                                                    'It can include a remote server to use with xrootd.', default = "")
   start_entry       = luigi.FloatParameter(description = 'starting point', default = 0)
   end_entry         = luigi.FloatParameter(description = 'ending point'  , default = 1)
   compression_algo  = luigi.Parameter(default = '', description = 'ZLIB, LZMA, LZ4')
@@ -72,6 +75,7 @@ class ShuffleMergeSpectral(Task, HTCondorWorkflow, law.LocalWorkflow):
       '--tau-ratio'         , quote(str(self.tau_ratio))] +\
       ## optional arguments
       ['--seed'             , str(self.seed)                    ] * (not self.seed              is '') +\
+      ['--prefix'           , str(self.prefix)                  ] * (not self.prefix            is '') +\
       ['--n-threads'        , str(self.n_threads)               ] * (not self.n_threads         is '') +\
       ['--disabled-branches', quote(str(self.disabled_branches))] * (not self.disabled_branches is '') +\
       ['--exp-disbalance'   , str(self.exp_disbalance)          ] * (not self.exp_disbalance    is '') +\

--- a/README.md
+++ b/README.md
@@ -184,7 +184,8 @@ python Analysis/python/CreateSpectralHists.py --input /path/to/input/dir/ \
 After spectrums are created for all datasets, the final procedure of Shuffle and Merge can be performed with:
 ```
 ShuffleMergeSpectral --cfg Analysis/config/2018/training_inputs_MC.cfg
-                     --input /eos/cms/store/group/phys_tau/TauML/prod_2018_v1/full_tuples
+                     --input input_files.txt
+                     --prefix prefix_string
                      --output <path_to_output_file.root>
                      --mode MergeAll
                      --n-threads 1
@@ -196,9 +197,18 @@ ShuffleMergeSpectral --cfg Analysis/config/2018/training_inputs_MC.cfg
                      --exp-disbalance 100
                      --start-entry 0.0 --end-entry 0.0008
 ```
+- `--input` is the file containing the list of input files (read line-by-line). Each entry (line) should be of the form "dataset/file" (no quotes). The rest of the path (the path to the dataset folders) should be specified in the `--prefix` argument.
+- `--prefix` is the prefix which will be placed before the path of each file read form `--input`. Please note that this prefix will *not* be placed before the `--input-spec` value. This value can include a remote path compatible with xrootd.
 - the last pt bin is taken as a high pt region, all entries from it are taken without rejection.
 - `--tau-ratio "jet:1, e:1, mu:1, tau:1"` defines proportion of TauTypes in final root-tuple.
 - `--start-entry 0.0 --end-entry 0.0008` defines from which percentage by which entries will be read within every input root file.
+
+The input files file can be generated as follows:
+```
+cd /path/to/datasets/folder
+find . -name '*.root' > file_list.txt
+```
+In this case, `--input` will be set to *file_list.txt* and `--prefix` will be set to */path/to/datasets/folder*.
 
 #### ShuffleMergeSpectral on HTCondor
 ShuffleMergeSpectral can be executed on condor through the [law](https://github.com/riga/law) package. To run it, first install law following [this](https://github.com/riga/law/wiki/Usage-at-CERN) instructions. Then, set up the environment 


### PR DESCRIPTION
This PR updates the Analysis/bin/ShuffleMergeSpectral.cxx to read the input files from a list. It also updates the corresponding law task and the readme.
The biggest modification involves the EntryDesc structure here https://github.com/cms-tau-pog/TauMLTools/blob/aba58f48ac0ac3922689061f9f258f2d33f9fa1a/Analysis/bin/ShuffleMergeSpectral.cxx#L165-L242

Input files are read line-by-line from a list saved in an external file. Each entry (line) should be of the form "dataset/file" (no quotes). The path to the dataset folders should be specified by the `--prefix` argument, and its value will be placed before each file path read from `--input`. The input file can be generated with:
```
cd /path/to/dataset/folders
find . -name '*.root' > file_list.txt
```
In this case, `--input` will be *file_list.txt*, and `--prefix` will be */path/to/dataset/folders*. The prefix can also specify a xrootd-compatible remote path. Please note that `--prefix` will *not* be placed before `--input-spec`.

You can test the code by running:
```
cd $CMSSW_BASE/src
cmsenv
source setup.sh
law index

cd /eos/cms/store/group/phys_tau/TauML/prod_2018_v1/full_tuples
find . -name '*.root' > $CMSSW_BASE/src/TauMLTools/Analysis/law/file_list.txt
cd $CMSSW_BASE/src/TauMLTools/Analysis/law

law run ShuffleMergeSpectral --version test \
--cfg $CMSSW_BASE/src/TauMLTools/Analysis/config/2018/training_inputs_MC.cfg \
--input-path $PWD/input_files.txt \
--prefix root://cmsxrootd-kit.gridka.de//store/user/aakhmets/TauML_TauTuples \
--output-path $PWD/test \
--mode MergeAll \
--input-spec /afs/cern.ch/work/m/myshched/public/root-tuple-v2-hists \
--pt-bins "20, 30, 40, 50, 60, 70, 80, 90, 100, 1000" \
--eta-bins "0., 0.6, 1.2, 1.8, 2.4" \
--tau-ratio "jet:1, e:1, mu:1, tau:1, emb_tau:-1, emb_jet:-1" \
--disabled-branches "trainingWeight, tauType" \
--n-jobs 5 --start-entry 0 --end-entry 0.001 --max-entries 10 --max-runtime 0.08 --batch-name test_SMS
```

