### PR TITLE
Update of Shuffle&Merge parallelization strategy 

### DIFF
--- a/Analysis/bin/CreateSpectralHists.cxx
+++ b/Analysis/bin/CreateSpectralHists.cxx
@@ -10,8 +10,12 @@
 #include "TauMLTools/Core/interface/RootExt.h"
 #include "TauMLTools/Analysis/interface/TauSelection.h"
 
+#include <iostream>
+#include <fstream>
+
 struct Arguments {
     run::Argument<std::string> outputfile{"outputfile", "output file name"};
+    run::Argument<std::string> output_entries{"output_entries", "txt output file with filenames and number of entries"};
     run::Argument<std::vector<std::string>> input_dirs{"input-dir", "input directory"};
     run::Argument<std::string> pt_hist{"pt-hist", "pt hist setup: (number of bins, pt_min, pt_max)", "200, 0.0, 1000"};
     run::Argument<std::string> eta_hist{"eta-hist", "eta hist setup: (number of bins, abs(eta)_min, abs(eta)_max)","4, 0.0, 2.3"};
@@ -65,6 +69,8 @@ public:
                                                   args.exclude_dir_list())),
       outputfile(root_ext::CreateRootFile(args.outputfile()))
     {
+      output_txt.open(args.output_entries(), std::ios::trunc);
+
       ROOT::EnableThreadSafety();
       if(args.n_threads() > 1) ROOT::EnableImplicitMT(args.n_threads());
 
@@ -86,6 +92,8 @@ public:
                       "genLepton_index", "genJet_index",
                       "genLepton_vis_pt", "genLepton_vis_eta", "genLepton_vis_phi", "genLepton_vis_mass",
                       "tau_pt", "tau_eta", "tau_phi", "tau_mass", "evt"});
+            
+            output_txt << file_name << " " << input_tauTuple.GetEntries() << "\n";
 
             for(const Tau& tau : input_tauTuple)
             {
@@ -100,6 +108,7 @@ public:
                   << "Number of taus within the ranges of histogram = " << Integral()
                   << " (" << Integral()/total_size*100 << "%)" << std::endl
                   << "Number of not Valid taus = " << hists->not_valid().GetEntries() << std::endl;
+        output_txt.close();
     }
 
 private:
@@ -156,6 +165,7 @@ private:
   private:
       std::vector<std::string> input_files;
       std::shared_ptr<TFile> outputfile;
+      std::ofstream output_txt;
       std::shared_ptr<HistSpectrum> hists;
       std::map<TauType,bool> ttypes;
       Int_t total_size=0;

--- a/Analysis/python/CreateSpectralHists.py
+++ b/Analysis/python/CreateSpectralHists.py
@@ -42,25 +42,36 @@ for dir_path in input_path:
     split_path = dir_path.split("/")
     if not os.path.isdir(dir_path): continue
 
-    output_file = args.output + "/" \
+    output_root = args.output + "/" \
                 + split_path[-1] + ".root"
+    output_entries = args.output + "/" \
+                + split_path[-1] + ".txt"
+                
 
-    if os.path.exists(output_file):
+    if os.path.exists(output_root):
         print("{} was already processed.".format(dir_path))
         if args.rewrite:
-            print("{} was removed".format(output_file))
-            os.remove(output_file)
+            print("{} was removed".format(output_root))
+            os.remove(output_root)
+        else:
+            continue
+    if os.path.exists(output_entries):
+        print("{} was already processed.".format(dir_path))
+        if args.rewrite:
+            print("{} was removed".format(output_entries))
+            os.remove(output_entries)
         else:
             continue
 
     print("Added {}...".format(dir_path))
 
-    cmd = 'CreateSpectralHists --output "{}" --input-dir "{}" --pt-hist "{}" --eta-hist "{}" --n-threads {}' \
-        .format(output_file, dir_path, pt_hist, eta_hist, args.n_threads)
+    cmd = 'CreateSpectralHists --outputfile "{}" --output_entries "{}" --input-dir "{}" --pt-hist "{}" --eta-hist "{}" --n-threads {}' \
+        .format(output_root, output_entries, dir_path, pt_hist, eta_hist, args.n_threads)
     result = subprocess.call([cmd], shell=True)
 
     if result != 0:
-        if os.path.exists(output_file):
-            os.remove(output_file)
+        if os.path.exists(output_root):
+            os.remove(output_root)
         raise RuntimeError("MergeTuples has failed.")
     print("{} has been successfully processed".format(dir_path))
+

--- a/README.md
+++ b/README.md
@@ -205,13 +205,14 @@ ShuffleMergeSpectral --cfg Analysis/config/2018/training_inputs_MC.cfg
                      --eta-bins "0., 0.6, 1.2, 1.8, 2.4"
                      --tau-ratio "jet:1, e:1, mu:1, tau:1"
                      --exp-disbalance 100
-                     --start-entry 0.0 --end-entry 0.0008
+                     --job-idx 0 --n-jobs 500
 ```
 - `--input` is the file containing the list of input files (read line-by-line). Each entry (line) should be of the form "dataset/file" (no quotes). The rest of the path (the path to the dataset folders) should be specified in the `--prefix` argument.
 - `--prefix` is the prefix which will be placed before the path of each file read form `--input`. Please note that this prefix will *not* be placed before the `--input-spec` value. This value can include a remote path compatible with xrootd.
 - the last pt bin is taken as a high pt region, all entries from it are taken without rejection.
 - `--tau-ratio "jet:1, e:1, mu:1, tau:1"` defines proportion of TauTypes in final root-tuple.
 - `--start-entry 0.0 --end-entry 0.0008` defines from which percentage by which entries will be read within every input root file.
+- `--n-jobs 500 --job-idx 0` defines into how many parts to split the input files and the index of corresponding job
 
 #### ShuffleMergeSpectral on HTCondor
 ShuffleMergeSpectral can be executed on condor through the [law](https://github.com/riga/law) package. To run it, first install law following [this](https://github.com/riga/law/wiki/Usage-at-CERN) instructions. Then, set up the environment 

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ shuf ./filelist.txt > ./filelist_mix.txt
 After spectrums are created for all datasets, the final procedure of Shuffle and Merge can be performed with:
 ```sh
 ShuffleMergeSpectral --cfg Analysis/config/2018/training_inputs_MC.cfg
-                     --input input_files.txt
+                     --input filelist_mix.txt
                      --prefix prefix_string
                      --output <path_to_output_file.root>
                      --mode MergeAll
@@ -212,13 +212,6 @@ ShuffleMergeSpectral --cfg Analysis/config/2018/training_inputs_MC.cfg
 - the last pt bin is taken as a high pt region, all entries from it are taken without rejection.
 - `--tau-ratio "jet:1, e:1, mu:1, tau:1"` defines proportion of TauTypes in final root-tuple.
 - `--start-entry 0.0 --end-entry 0.0008` defines from which percentage by which entries will be read within every input root file.
-
-The input files file can be generated as follows:
-```
-cd /path/to/datasets/folder
-find . -name '*.root' > file_list.txt
-```
-In this case, `--input` will be set to *file_list.txt* and `--prefix` will be set to */path/to/datasets/folder*.
 
 #### ShuffleMergeSpectral on HTCondor
 ShuffleMergeSpectral can be executed on condor through the [law](https://github.com/riga/law) package. To run it, first install law following [this](https://github.com/riga/law/wiki/Usage-at-CERN) instructions. Then, set up the environment 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ cmsrel CMSSW_10_6_20
 cd CMSSW_10_6_20/src
 cmsenv
 git cms-merge-topic -u cms-tau-pog:CMSSW_10_6_X_tau-pog_boostedTausMiniFix
-git clone -o cms-tau-pog -b prod2018_v2 git@github.com:cms-tau-pog/TauMLTools.git
+git clone -o cms-tau-pog -b master git@github.com:cms-tau-pog/TauMLTools.git
 scram b -j8
 ```
 
@@ -165,9 +165,10 @@ ShuffleMerge --cfg TauML/Analysis/config/testing_inputs.cfg --input tuples-v2 --
 
 This step represents alternative Shuffle and Merge procedure that aims to minimize usage of physicical memory as well as provide direct control over the shape of final (pt,eta) spectrum.
 
-To generate the specturum histograms of a dataset, run:
-```
+To generate the specturum histograms for a dataset and lists with number of entries per datafile, run:
+```sh
 CreateSpectralHists --output "spectrum_file.root" \
+                    --output_entries "entires_file.txt" \
                     --input-dir "path/to/dataset/dir" \
                     --pt-hist "n_bins_pt, pt_min, pt_max" \
                     --eta-hist "n_bins_eta, |eta|_min, |eta|_max" \
@@ -175,15 +176,23 @@ CreateSpectralHists --output "spectrum_file.root" \
 ```
 
 Alternatively, if one wants to process several datasets the following python script can be used (parameters of pt and eta binning to be hardcoded in the script):
-```
+```sh
 python Analysis/python/CreateSpectralHists.py --input /path/to/input/dir/ \
                                               --output /path/to/output/dir/ \
                                               --filter ".*(DY).*" \
                                               --rewrite
 ```
+After following step is executed, to create common file with datafile names and entries:
+```sh
+for i in <path_to_spectrums>/*.txt; do cat $i >> filelist.txt ; done
 
-After spectrums are created for all datasets, the final procedure of Shuffle and Merge can be performed with:
 ```
+To mix the file names:
+```sh
+shuf ./filelist.txt > ./filelist_mix.txt
+```
+After spectrums are created for all datasets, the final procedure of Shuffle and Merge can be performed with:
+```sh
 ShuffleMergeSpectral --cfg Analysis/config/2018/training_inputs_MC.cfg
                      --input input_files.txt
                      --prefix prefix_string


### PR DESCRIPTION
In the following pull request changes of the parallelization and the pt-eta spectrum smoothing are introduced:

1. CreateSpectralHists.cxx and CreateSpectralHists.py are updated to create text files with the data files names and number of the entries.
2. ShuffleMergeSpectral.cxx is updated to parallelize input data files into --n-jobs. (Option of parallelization by 
3. Option to take into account last pt-bin when calculating the probability of rejecting events by pt-eta is added (in addition to the option to take all events from the last pt-bin of the histogram)
4. README is updated to include corresponding options.