### PR TITLE
On-flight spectrum in Shuffle&Merge 

### DIFF
--- a/Analysis/bin/ShuffleMergeSpectral.cxx
+++ b/Analysis/bin/ShuffleMergeSpectral.cxx
@@ -330,7 +330,7 @@ public:
       for (TauType type: ttypes){
         std::shared_ptr<TH2D> hist_ttype((TH2D*)current_file->Get(("eta_pt_hist_"+ToString(type)).c_str()));
         if (!hist_ttype)
-          throw exception("TauType: '%1%' is not available at enable_emptybin'%2%'")
+          throw exception("TauType: '%1%' is not available at '%2%'")
           % ToString(type) % path_spectrum_file;
         root_ext::RebinAndFill(*ttype_entries[type], *hist_ttype);
         n_entries += hist_ttype->GetEntries();
@@ -376,6 +376,10 @@ public:
         Int_t MaxBin = ttype_prob.at(type)->GetMaximumBin();
         Int_t x,y,z;
         ttype_prob.at(type)->GetBinXYZ(MaxBin, x, y, z);
+
+        if(ttype_prob.at(type)->GetBinContent(x,y)==0)
+          throw exception("Histogram '%1%' in '%4%' is empty.")
+          % ToString(type) % groupname;
 
         if(exp_disbalance==0) { // option 1: last pt bin will be taken into account for probability calculations
           ttype_prob.at(type)->Scale(1.0/ttype_prob.at(type)->GetBinContent(x,y));

--- a/Analysis/bin/ShuffleMergeSpectral.cxx
+++ b/Analysis/bin/ShuffleMergeSpectral.cxx
@@ -366,10 +366,11 @@ public:
                 throw exception("Empty bin (pt_i:'%1%', eta_i:'%2%') for tau type '%3%' in '%4%'.")
                 % i_x % i_y % ToString(type) % groupname;
               }
-            }
+            } else {
             ratio_h->SetBinContent(i_x,i_y,
               target_hist->GetBinContent(i_x,i_y)/ttype_entries.at(type)->GetBinContent(i_x,i_y));
-          }
+            }
+	  }
         }
         ttype_prob.at(type) = ratio_h;
         Int_t MaxBin = ttype_prob.at(type)->GetMaximumBin();

--- a/Analysis/config/2018/training_inputs_MC.cfg
+++ b/Analysis/config/2018/training_inputs_MC.cfg
@@ -1,4 +1,4 @@
-# DY: dir=(DY.*) file=eventTuple.* types=jet,e,mu,tau
+DY: dir=(DY.*) file=eventTuple.* types=jet,e,mu,tau
 TT: dir=(TTJets.*|TTTo2L2Nu.*|TTToSemiLeptonic.*) file=eventTuple.* types=jet,e,mu,tau
 TT_had: dir=(TTToHadronic.*) file=eventTuple.* types=jet,e,mu
 W:  dir=(W1Jets.*|W2Jets.*|W3Jets.*|W4Jets.*|WJets.*) file=eventTuple.* types=jet,e,mu,tau

--- a/Analysis/config/2018/training_inputs_MC.cfg
+++ b/Analysis/config/2018/training_inputs_MC.cfg
@@ -1,8 +1,11 @@
-DY: dir=(DY.*) file=eventTuple.* types=jet,e,mu,tau
-TT: dir=(TT.*) file=eventTuple.* types=jet,e,mu,tau
+# DY: dir=(DY.*) file=eventTuple.* types=jet,e,mu,tau
+TT: dir=(TTJets.*|TTTo2L2Nu.*|TTToSemiLeptonic.*) file=eventTuple.* types=jet,e,mu,tau
+TT_had: dir=(TTToHadronic.*) file=eventTuple.* types=jet,e,mu
 W:  dir=(W1Jets.*|W2Jets.*|W3Jets.*|W4Jets.*|WJets.*) file=eventTuple.* types=jet,e,mu,tau
 QCD: dir=(QCD.*) file=eventTuple.* types=jet
 Higgs: dir=(ttHTo.*|GluGluHTo.*|ZHTo.*|WplusHTo.*|WminusHTo.*|VBF.*|GluGlu.*) file=eventTuple.* types=tau
-Zprime: dir=(Zprime.*) file=eventTuple.* types=e,mu,tau
+Zprime_e: dir=(ZprimeToEE.*) file=eventTuple.* types=e
 TauGun: dir=(TauGun.*) file=eventTuple.* types=tau
-Emb: dir=(Embedded.*) file=eventTuple.* types=emb_tau,emb_jet
+# Zprime_tau: dir=(ZprimeToTauTau.*) file=eventTuple.* types=tau
+# Zprime_mu: dir=(ZprimeToMuMu.*) file=eventTuple.* types=mu
+# Emb: dir=(Embedded.*) file=eventTuple.* types=emb_tau,emb_jet

--- a/Analysis/law/ShuffleMergeSpectral/tasks.py
+++ b/Analysis/law/ShuffleMergeSpectral/tasks.py
@@ -87,7 +87,7 @@ class ShuffleMergeSpectral(Task, HTCondorWorkflow, law.LocalWorkflow):
       ['--compression-level', str(self.compression_level)       ] * (not self.compression_level  is '') +\
       ['--parity'           , str(self.parity)                  ] * (not self.parity             is '') +\
       ['--max-entries'      , str(self.max_entries)             ] * (not self.max_entries        is '') +\
-      ['--enable-emptybin'] , str(self.enable_emptybin)         ] * (not self.enable_emptybin    is '') +\
+      ['--enable-emptybin'  , str(self.enable_emptybin)         ] * (not self.enable_emptybin    is '') +\
       ['--refill-spectrum"' , str(self.refill_spectrum)         ] * (not self.refill_spectrum    is '')  )
 
     print ('>> {}'.format(command))

--- a/Analysis/law/ShuffleMergeSpectral/tasks.py
+++ b/Analysis/law/ShuffleMergeSpectral/tasks.py
@@ -88,7 +88,7 @@ class ShuffleMergeSpectral(Task, HTCondorWorkflow, law.LocalWorkflow):
       ['--parity'           , str(self.parity)                  ] * (not self.parity             is '') +\
       ['--max-entries'      , str(self.max_entries)             ] * (not self.max_entries        is '') +\
       ['--enable-emptybin'  , str(self.enable_emptybin)         ] * (not self.enable_emptybin    is '') +\
-      ['--refill-spectrum"' , str(self.refill_spectrum)         ] * (not self.refill_spectrum    is '')  )
+      ['--refill-spectrum' , str(self.refill_spectrum)         ] * (not self.refill_spectrum    is '')  )
 
     print ('>> {}'.format(command))
     proc = subprocess.Popen(command, shell = True, stdout = subprocess.PIPE, stderr = subprocess.PIPE)

--- a/Analysis/law/ShuffleMergeSpectral/tasks.py
+++ b/Analysis/law/ShuffleMergeSpectral/tasks.py
@@ -34,6 +34,8 @@ class ShuffleMergeSpectral(Task, HTCondorWorkflow, law.LocalWorkflow):
   n_threads         = luigi.Parameter(default = '', description = 'number of threads')
   lastbin_disbalance= luigi.Parameter(default = '', description = 'maximal acceptable disbalance between low pt and high pt region')
   seed              = luigi.Parameter(default = '', description = 'random seed to initialize the generator used for sampling')
+  enable_emptybin   = luigi.Parameter(default = '', description = 'enable empty pt-eta bins in the spectrum')
+  refill_spectrum   = luigi.Parameter(default = '', description = 'to recalculated spectrums of the input data on flight')
 
   def create_branch_map(self):
     self.output_dir = '/'.join([self.output_path, 'tmp'])
@@ -84,7 +86,9 @@ class ShuffleMergeSpectral(Task, HTCondorWorkflow, law.LocalWorkflow):
       ['--compression-algo' , str(self.compression_algo)        ] * (not self.compression_algo   is '') +\
       ['--compression-level', str(self.compression_level)       ] * (not self.compression_level  is '') +\
       ['--parity'           , str(self.parity)                  ] * (not self.parity             is '') +\
-      ['--max-entries'      , str(self.max_entries)             ] * (not self.max_entries        is '')  )
+      ['--max-entries'      , str(self.max_entries)             ] * (not self.max_entries        is '') +\
+      ['--enable-emptybin'] , str(self.enable_emptybin)         ] * (not self.enable_emptybin    is '') +\
+      ['--refill-spectrum"' , str(self.refill_spectrum)         ] * (not self.refill_spectrum    is '')  )
 
     print ('>> {}'.format(command))
     proc = subprocess.Popen(command, shell = True, stdout = subprocess.PIPE, stderr = subprocess.PIPE)

--- a/Core/interface/SmartTree.h
+++ b/Core/interface/SmartTree.h
@@ -221,10 +221,10 @@ public:
 
     SmartTree(const std::string& _name, const std::vector<std::string>& list,
               const std::set<std::string>& _disabled_branches = {}, const std::set<std::string>& _enabled_branches ={})
-        : name(_name), directory(nullptr), disabled_branches(_disabled_branches),
+        : name(_name), directory(nullptr), readMode(true), disabled_branches(_disabled_branches),
           enabled_branches(_enabled_branches)
     {
-        static constexpr Long64_t maxVirtualSize = 200 * 1024 * 1024;
+        static constexpr Long64_t maxVirtualSize = 100 * 1024 * 1024;
 
         TChain* fchain = new TChain("taus");
         for(const std::string& file: list)

--- a/Production/scripts/validation_tool.py
+++ b/Production/scripts/validation_tool.py
@@ -133,10 +133,10 @@ if __name__ == '__main__':
   model = lambda main, third = None: (main, '', N_SPLIT, 0, N_SPLIT)+BINS[main]+BINS[third] if not third is None else (main, '', N_SPLIT, 0, N_SPLIT)+BINS[main]
   
   cpp_function = '''
-std::vector<int> hash_list = {%s};
+std::vector<ULong64_t> hash_list = {%s};
 int hash, line = 0;
-for(std::vector<int>::iterator it = hash_list.begin(); it != hash_list.end(); it++, line++){
- if (*it == %s) return line;
+for(std::vector<ULong64_t>::iterator it = hash_list.begin(); it != hash_list.end(); it++, line++){
+if (*it == %s) return line;
 } return line;'''
 
   id_json       = json.load(open(args.id_json, 'r'))

--- a/README.md
+++ b/README.md
@@ -204,14 +204,17 @@ ShuffleMergeSpectral --cfg Analysis/config/2018/training_inputs_MC.cfg
                      --pt-bins "20, 30, 40, 50, 60, 70, 80, 90, 100, 1000"
                      --eta-bins "0., 0.6, 1.2, 1.8, 2.4"
                      --tau-ratio "jet:1, e:1, mu:1, tau:1"
-                     --exp-disbalance 100
+                     --lastbin-disbalance 0.0
+                     --refill-spectrum true
+                     --enable-emptybin true
                      --job-idx 0 --n-jobs 500
 ```
 - `--input` is the file containing the list of input files (read line-by-line). Each entry (line) should be of the form "dataset/file" (no quotes). The rest of the path (the path to the dataset folders) should be specified in the `--prefix` argument.
 - `--prefix` is the prefix which will be placed before the path of each file read form `--input`. Please note that this prefix will *not* be placed before the `--input-spec` value. This value can include a remote path compatible with xrootd.
 - the last pt bin is taken as a high pt region, all entries from it are taken without rejection.
 - `--tau-ratio "jet:1, e:1, mu:1, tau:1"` defines proportion of TauTypes in final root-tuple.
-- `--start-entry 0.0 --end-entry 0.0008` defines from which percentage by which entries will be read within every input root file.
+- `--refill-spectrum` to recalculated spectrums of the input data on flight (only events that are corresponds to the current job `--job-idx` will be considered)
+- `--enable-emptybin` in case of empty pt-eta bin, the probability in this bin will be set to 0 (that is needed in cases when datasets are not big or the number of jobs(`--n-jobs`) is big)
 - `--n-jobs 500 --job-idx 0` defines into how many parts to split the input files and the index of corresponding job
 
 #### ShuffleMergeSpectral on HTCondor

--- a/Training/configs/training_v1.yaml
+++ b/Training/configs/training_v1.yaml
@@ -10,18 +10,18 @@ Setup:
     n_threads            :  1
     # tau_types_names.keys are written in accordance with tauType in the tau tuple
     tau_types_names      : { "0":"e", "1":"mu", "2":"tau", "3":"jet" }
-    input_dirs           : ["/eos/user/m/myshched/LawTest_flush10_virt10_v3/"]
-    file_name_pattern    : "^.*_(21|22|23|24|25|26|27|28|29).root$"
+    input_dirs           : ["/eos/cms/store/group/phys_tau/TauML/prod_2018_v2/ShuffleMergeSpectral_v1/"]
+    file_name_pattern    : "^.*_(1|2|3).root$"
     exclude_list         : ""
     exclude_dir_list     : ""
-    input_spectrum       : "/eos/home-m/myshched/ShuffleSpectrum.root"
-    target_spectrum      : "/eos/home-m/myshched/ShuffleSpectrum.root"
-    n_pt_bins            : 49
+    input_spectrum       : "<PATH_TO_SPECTRUM>/ShuffleSpectrum.root"
+    target_spectrum      : "<PATH_TO_SPECTRUM>/ShuffleSpectrum.root"
+    n_pt_bins            : 7
     pt_min               : 20.0
     pt_max               : 1000.0
     n_eta_bins           : 4
     eta_min              : 0.0
-    eta_max              : 2.3
+    eta_max              : 2.5
     weight_thr           : 100000.0
 
 CellObjectType : [
@@ -42,15 +42,15 @@ Features_all :
                 "tau_charge",
                 "tau_n_charged_prongs",
                 "tau_n_neutral_prongs",
-                "chargedIsoPtSum",
-                "chargedIsoPtSumdR03_over_dR05",
-                "footprintCorrection",
-                "neutralIsoPtSum",
-                "neutralIsoPtSumWeight_over_neutralIsoPtSum",
-                "neutralIsoPtSumWeightdR03_over_neutralIsoPtSum",
-                "neutralIsoPtSumdR03_over_dR05",
-                "photonPtSumOutsideSignalCone",
-                "puCorrPtSum",
+                "tau_chargedIsoPtSum",
+                "tau_chargedIsoPtSumdR03_over_dR05",
+                "tau_footprintCorrection",
+                "tau_neutralIsoPtSum",
+                "tau_neutralIsoPtSumWeight_over_neutralIsoPtSum",
+                "tau_neutralIsoPtSumWeightdR03_over_neutralIsoPtSum",
+                "tau_neutralIsoPtSumdR03_over_dR05",
+                "tau_photonPtSumOutsideSignalCone",
+                "tau_puCorrPtSum",
                 "tau_dxy_valid",
                 "tau_dxy",
                 "tau_dxy_sig",
@@ -76,7 +76,7 @@ Features_all :
                 "tau_n_photons",
                 "tau_emFraction",
                 "tau_inside_ecal_crack",
-                "leadChargedCand_etaAtEcalEntrance_minus_tau_eta"
+                "tau_leadChargedCand_etaAtEcalEntrance_minus_tau_eta"
                 ]
 
     PfCand_electron : [
@@ -88,7 +88,7 @@ Features_all :
                 "pfCand_ele_puppiWeight",
                 "pfCand_ele_charge",
                 "pfCand_ele_lostInnerHits",
-                "pfCand_ele_numberOfPixelHits",
+                "pfCand_ele_nPixelHits",
                 "pfCand_ele_vertex_dx",
                 "pfCand_ele_vertex_dy",
                 "pfCand_ele_vertex_dz",
@@ -114,7 +114,7 @@ Features_all :
               "pfCand_muon_puppiWeight",
               "pfCand_muon_charge",
               "pfCand_muon_lostInnerHits",
-              "pfCand_muon_numberOfPixelHits",
+              "pfCand_muon_nPixelHits",
               "pfCand_muon_vertex_dx",
               "pfCand_muon_vertex_dy",
               "pfCand_muon_vertex_dz",
@@ -135,14 +135,14 @@ Features_all :
               "pfCand_chHad_rel_pt",
               "pfCand_chHad_deta",
               "pfCand_chHad_dphi",
-              "pfCand_chHad_leadChargedHadrCand",
+              "pfCand_chHad_tauLeadChargedHadrCand",
               "pfCand_chHad_pvAssociationQuality",
               "pfCand_chHad_fromPV",
               "pfCand_chHad_puppiWeight",
               "pfCand_chHad_puppiWeightNoLep",
               "pfCand_chHad_charge",
               "pfCand_chHad_lostInnerHits",
-              "pfCand_chHad_numberOfPixelHits",
+              "pfCand_chHad_nPixelHits",
               "pfCand_chHad_vertex_dx",
               "pfCand_chHad_vertex_dy",
               "pfCand_chHad_vertex_dz",
@@ -180,7 +180,7 @@ Features_all :
               "pfCand_gamma_puppiWeight",
               "pfCand_gamma_puppiWeightNoLep",
               "pfCand_gamma_lostInnerHits",
-              "pfCand_gamma_numberOfPixelHits",
+              "pfCand_gamma_nPixelHits",
               "pfCand_gamma_vertex_dx",
               "pfCand_gamma_vertex_dy",
               "pfCand_gamma_vertex_dz",

--- a/Training/interface/DataLoader_main.h
+++ b/Training/interface/DataLoader_main.h
@@ -1,4 +1,3 @@
-#include "TauMLTools/Core/interface/AnalysisMath.h"
 #include "TauMLTools/Analysis/interface/TauTuple.h"
 #include "TauMLTools/Training/interface/DataLoader_tools.h"
 
@@ -141,6 +140,7 @@ class DataLoader {
 public:
     using Tau = tau_tuple::Tau;
     using TauTuple = tau_tuple::TauTuple;
+    using LorentzVectorM = ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double>>;
 
     DataLoader() : current_entry(start_dataset),
         innerCellGridRef(n_inner_cells, n_inner_cells, inner_cell_size, inner_cell_size),
@@ -178,6 +178,9 @@ public:
             RebinAndFill(*hist_weights[tau_type], *target_hist);
             RebinAndFill(*after_rebin_input_hist, *input_hist);
         } else throw std::runtime_error("Error: Spectrum hist is nullptr");
+        if(after_rebin_input_hist.get()->GetBinContent(after_rebin_input_hist.get()->GetMinimumBin()) <= 0) {
+          throw std::runtime_error("Error: Target histogram has empty bins");
+        }
         hist_weights[tau_type]->Divide(after_rebin_input_hist.get());
       }
 
@@ -291,23 +294,23 @@ public:
         fill_tau(TauFlat_Features::tau_phi, tau.tau_phi);
         fill_tau(TauFlat_Features::tau_mass, tau.tau_mass);
 
-        const analysis::LorentzVectorM tau_p4(tau.tau_pt, tau.tau_eta, tau.tau_phi, tau.tau_mass);
+        const LorentzVectorM tau_p4(tau.tau_pt, tau.tau_eta, tau.tau_phi, tau.tau_mass);
         fill_tau(TauFlat_Features::tau_E_over_pt, tau_p4.energy() / tau.tau_pt);
         fill_tau(TauFlat_Features::tau_charge, tau.tau_charge);
         fill_tau(TauFlat_Features::tau_n_charged_prongs, tau.tau_decayMode / 5);
         fill_tau(TauFlat_Features::tau_n_neutral_prongs, tau.tau_decayMode % 5);
-        fill_tau(TauFlat_Features::chargedIsoPtSum, tau.chargedIsoPtSum);
-        if(tau.chargedIsoPtSum!=0)
-          fill_tau(TauFlat_Features::chargedIsoPtSumdR03_over_dR05, tau.chargedIsoPtSumdR03 / tau.chargedIsoPtSum);
-        fill_tau(TauFlat_Features::footprintCorrection, tau.footprintCorrection);
-        fill_tau(TauFlat_Features::neutralIsoPtSum, tau.neutralIsoPtSum);
-        if(tau.neutralIsoPtSum!=0) {
-          fill_tau(TauFlat_Features::neutralIsoPtSumWeight_over_neutralIsoPtSum, tau.neutralIsoPtSumWeight / tau.neutralIsoPtSum);
-          fill_tau(TauFlat_Features::neutralIsoPtSumWeightdR03_over_neutralIsoPtSum,tau.neutralIsoPtSumWeightdR03 / tau.neutralIsoPtSum);
-          fill_tau(TauFlat_Features::neutralIsoPtSumdR03_over_dR05, tau.neutralIsoPtSumdR03 / tau.neutralIsoPtSum);
+        fill_tau(TauFlat_Features::tau_chargedIsoPtSum, tau.tau_chargedIsoPtSum);
+        if(tau.tau_chargedIsoPtSum!=0)
+          fill_tau(TauFlat_Features::tau_chargedIsoPtSumdR03_over_dR05, tau.tau_chargedIsoPtSumdR03 / tau.tau_chargedIsoPtSum);
+        fill_tau(TauFlat_Features::tau_footprintCorrection, tau.tau_footprintCorrection);
+        fill_tau(TauFlat_Features::tau_neutralIsoPtSum, tau.tau_neutralIsoPtSum);
+        if(tau.tau_neutralIsoPtSum!=0) {
+          fill_tau(TauFlat_Features::tau_neutralIsoPtSumWeight_over_neutralIsoPtSum, tau.tau_neutralIsoPtSumWeight / tau.tau_neutralIsoPtSum);
+          fill_tau(TauFlat_Features::tau_neutralIsoPtSumWeightdR03_over_neutralIsoPtSum,tau.tau_neutralIsoPtSumWeightdR03 / tau.tau_neutralIsoPtSum);
+          fill_tau(TauFlat_Features::tau_neutralIsoPtSumdR03_over_dR05, tau.tau_neutralIsoPtSumdR03 / tau.tau_neutralIsoPtSum);
         }
-        fill_tau(TauFlat_Features::photonPtSumOutsideSignalCone, tau.photonPtSumOutsideSignalCone);
-        fill_tau(TauFlat_Features::puCorrPtSum, tau.puCorrPtSum);
+        fill_tau(TauFlat_Features::tau_photonPtSumOutsideSignalCone, tau.tau_photonPtSumOutsideSignalCone);
+        fill_tau(TauFlat_Features::tau_puCorrPtSum, tau.tau_puCorrPtSum);
 
         const bool tau_dxy_valid = std::isnormal(tau.tau_dxy) && tau.tau_dxy > - 10
                                    && std::isnormal(tau.tau_dxy_error) && tau.tau_dxy_error > 0;
@@ -358,7 +361,7 @@ public:
         fill_tau(TauFlat_Features::tau_n_photons, tau.tau_n_photons);
         fill_tau(TauFlat_Features::tau_emFraction, tau.tau_emFraction);
         fill_tau(TauFlat_Features::tau_inside_ecal_crack, tau.tau_inside_ecal_crack);
-        fill_tau(TauFlat_Features::leadChargedCand_etaAtEcalEntrance_minus_tau_eta, tau.leadChargedCand_etaAtEcalEntrance);
+        fill_tau(TauFlat_Features::tau_leadChargedCand_etaAtEcalEntrance_minus_tau_eta, tau.tau_leadChargedCand_etaAtEcalEntrance - tau.tau_eta);
 
       }
 
@@ -455,7 +458,7 @@ public:
               fillGrid(Br::pfCand_ele_puppiWeight, tau.pfCand_puppiWeight.at(pfCand_idx));
               fillGrid(Br::pfCand_ele_charge, tau.pfCand_charge.at(pfCand_idx));
               fillGrid(Br::pfCand_ele_lostInnerHits, tau.pfCand_lostInnerHits.at(pfCand_idx));
-              fillGrid(Br::pfCand_ele_numberOfPixelHits, tau.pfCand_numberOfPixelHits.at(pfCand_idx));
+              fillGrid(Br::pfCand_ele_nPixelHits, tau.pfCand_nPixelHits.at(pfCand_idx));
 
               fillGrid(Br::pfCand_ele_vertex_dx, tau.pfCand_vertex_x.at(pfCand_idx) - tau.pv_x);
               fillGrid(Br::pfCand_ele_vertex_dy, tau.pfCand_vertex_y.at(pfCand_idx) - tau.pv_y);
@@ -500,7 +503,7 @@ public:
               fillGrid(Br::pfCand_muon_puppiWeight, tau.pfCand_puppiWeight.at(pfCand_idx));
               fillGrid(Br::pfCand_muon_charge, tau.pfCand_charge.at(pfCand_idx));
               fillGrid(Br::pfCand_muon_lostInnerHits, tau.pfCand_lostInnerHits.at(pfCand_idx));
-              fillGrid(Br::pfCand_muon_numberOfPixelHits, tau.pfCand_numberOfPixelHits.at(pfCand_idx));
+              fillGrid(Br::pfCand_muon_nPixelHits, tau.pfCand_nPixelHits.at(pfCand_idx));
 
               fillGrid(Br::pfCand_muon_vertex_dx,  tau.pfCand_vertex_x.at(pfCand_idx) - tau.pv_x);
               fillGrid(Br::pfCand_muon_vertex_dy, tau.pfCand_vertex_y.at(pfCand_idx) - tau.pv_y);
@@ -540,14 +543,14 @@ public:
             fillGrid(Br::pfCand_chHad_rel_pt, tau.pfCand_pt.at(pfCand_idx) / tau.tau_pt);
             fillGrid(Br::pfCand_chHad_deta, tau.pfCand_eta.at(pfCand_idx) - tau.tau_eta );
             fillGrid(Br::pfCand_chHad_dphi, DeltaPhi(tau.pfCand_phi.at(pfCand_idx), tau.tau_phi));
-            fillGrid(Br::pfCand_chHad_leadChargedHadrCand, tau.pfCand_leadChargedHadrCand.at(pfCand_idx));
+            fillGrid(Br::pfCand_chHad_tauLeadChargedHadrCand, tau.pfCand_tauLeadChargedHadrCand.at(pfCand_idx));
             fillGrid(Br::pfCand_chHad_pvAssociationQuality, tau.pfCand_pvAssociationQuality.at(pfCand_idx));
             fillGrid(Br::pfCand_chHad_fromPV, tau.pfCand_fromPV.at(pfCand_idx));
             fillGrid(Br::pfCand_chHad_puppiWeight, tau.pfCand_puppiWeight.at(pfCand_idx));
             fillGrid(Br::pfCand_chHad_puppiWeightNoLep, tau.pfCand_puppiWeightNoLep.at(pfCand_idx));
             fillGrid(Br::pfCand_chHad_charge, tau.pfCand_charge.at(pfCand_idx));
             fillGrid(Br::pfCand_chHad_lostInnerHits, tau.pfCand_lostInnerHits.at(pfCand_idx));
-            fillGrid(Br::pfCand_chHad_numberOfPixelHits, tau.pfCand_numberOfPixelHits.at(pfCand_idx));
+            fillGrid(Br::pfCand_chHad_nPixelHits, tau.pfCand_nPixelHits.at(pfCand_idx));
 
             fillGrid(Br::pfCand_chHad_vertex_dx, tau.pfCand_vertex_x.at(pfCand_idx) - tau.pv_x);
             fillGrid(Br::pfCand_chHad_vertex_dy, tau.pfCand_vertex_y.at(pfCand_idx) - tau.pv_y);
@@ -610,7 +613,7 @@ public:
             fillGrid(Br::pfCand_gamma_puppiWeight, tau.pfCand_puppiWeight.at(pfCand_idx));
             fillGrid(Br::pfCand_gamma_puppiWeightNoLep, tau.pfCand_puppiWeightNoLep.at(pfCand_idx));
             fillGrid(Br::pfCand_gamma_lostInnerHits, tau.pfCand_lostInnerHits.at(pfCand_idx));
-            fillGrid(Br::pfCand_gamma_numberOfPixelHits, tau.pfCand_numberOfPixelHits.at(pfCand_idx));
+            fillGrid(Br::pfCand_gamma_nPixelHits, tau.pfCand_nPixelHits.at(pfCand_idx));
 
             fillGrid(Br::pfCand_gamma_vertex_dx, tau.pfCand_vertex_x.at(pfCand_idx) - tau.pv_x);
             fillGrid(Br::pfCand_gamma_vertex_dy, tau.pfCand_vertex_y.at(pfCand_idx) - tau.pv_y);
@@ -770,20 +773,23 @@ public:
           return std::max(cone_opening_coef / std::max(pt, min_pt), min_radius);
       }
 
-      static CellObjectType GetCellObjectType(int pdgId)
-      {
-          static const std::map<int, CellObjectType> obj_types = {
-              { 11, CellObjectType::PfCand_electron },
-              { 13, CellObjectType::PfCand_muon },
-              { 22, CellObjectType::PfCand_gamma },
-              { 130, CellObjectType::PfCand_nHad },
-              { 211, CellObjectType::PfCand_chHad }
-          };
+      static bool isSameCellObjectType(int particleType, CellObjectType type)
+      { 
+          static const std::set<int> other_types = {0, 6, 7};
 
-          auto iter = obj_types.find(std::abs(pdgId));
+          static const std::map<int, CellObjectType> obj_types = {
+              { 2, CellObjectType::PfCand_electron },
+              { 3, CellObjectType::PfCand_muon },
+              { 4, CellObjectType::PfCand_gamma },
+              { 5, CellObjectType::PfCand_nHad },
+              { 1, CellObjectType::PfCand_chHad }
+          };
+          
+          if(other_types.find(particleType) != other_types.end()) return false;
+          auto iter = obj_types.find(particleType);
           if(iter == obj_types.end())
-              throw std::runtime_error("Unknown object pdg id = "+std::to_string(pdgId));
-          return iter->second;
+              throw std::runtime_error("Unknown object of particleType = "+std::to_string(particleType));
+          return iter->second==type;
       }
 
       CellGrid CreateCellGrid(const Tau& tau, const CellGrid& cellGridRef, bool inner) const
@@ -792,12 +798,12 @@ public:
           CellGrid grid = cellGridRef;
           const double tau_pt = tau.tau_pt, tau_eta = tau.tau_eta, tau_phi = tau.tau_phi;
 
-          const auto fillGrid = [&](CellObjectType type, const std::vector<float>& eta_vec,
-                                    const std::vector<float>& phi_vec, const std::vector<int>& pdgId = {}) {
+          const auto fillCells = [&](CellObjectType type, const std::vector<float>& eta_vec,
+                                    const std::vector<float>& phi_vec, const std::vector<int>& particleType = {}) {
               if(eta_vec.size() != phi_vec.size())
                   throw std::runtime_error("Inconsistent cell inputs.");
               for(size_t n = 0; n < eta_vec.size(); ++n) {
-                  if(pdgId.size() && GetCellObjectType(pdgId.at(n)) != type) continue;
+                  if(particleType.size() && !isSameCellObjectType(particleType.at(n),type)) continue;
                   const double eta = eta_vec.at(n), phi = phi_vec.at(n);
                   const double deta = eta - tau_eta, dphi = DeltaPhi(phi, tau_phi);
                   const double dR = std::hypot(deta, dphi);
@@ -812,13 +818,13 @@ public:
               }
           };
 
-          fillGrid(CellObjectType::PfCand_electron, tau.pfCand_eta, tau.pfCand_phi, tau.pfCand_pdgId);
-          fillGrid(CellObjectType::PfCand_muon, tau.pfCand_eta, tau.pfCand_phi, tau.pfCand_pdgId);
-          fillGrid(CellObjectType::PfCand_chHad, tau.pfCand_eta, tau.pfCand_phi, tau.pfCand_pdgId);
-          fillGrid(CellObjectType::PfCand_nHad, tau.pfCand_eta, tau.pfCand_phi, tau.pfCand_pdgId);
-          fillGrid(CellObjectType::PfCand_gamma, tau.pfCand_eta, tau.pfCand_phi, tau.pfCand_pdgId);
-          fillGrid(CellObjectType::Electron, tau.ele_eta, tau.ele_phi);
-          fillGrid(CellObjectType::Muon, tau.muon_eta, tau.muon_phi);
+          fillCells(CellObjectType::PfCand_electron, tau.pfCand_eta, tau.pfCand_phi, tau.pfCand_particleType);
+          fillCells(CellObjectType::PfCand_muon, tau.pfCand_eta, tau.pfCand_phi, tau.pfCand_particleType);
+          fillCells(CellObjectType::PfCand_chHad, tau.pfCand_eta, tau.pfCand_phi, tau.pfCand_particleType);
+          fillCells(CellObjectType::PfCand_nHad, tau.pfCand_eta, tau.pfCand_phi, tau.pfCand_particleType);
+          fillCells(CellObjectType::PfCand_gamma, tau.pfCand_eta, tau.pfCand_phi, tau.pfCand_particleType);
+          fillCells(CellObjectType::Electron, tau.ele_eta, tau.ele_phi);
+          fillCells(CellObjectType::Muon, tau.muon_eta, tau.muon_phi);
 
           return grid;
       }

--- a/Training/interface/DataLoader_main.h
+++ b/Training/interface/DataLoader_main.h
@@ -142,16 +142,17 @@ public:
     using TauTuple = tau_tuple::TauTuple;
     using LorentzVectorM = ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double>>;
 
-    DataLoader() : current_entry(start_dataset),
+    DataLoader(const std::vector<std::string> file_name) :
+        current_entry(start_dataset),
         innerCellGridRef(n_inner_cells, n_inner_cells, inner_cell_size, inner_cell_size),
         outerCellGridRef(n_outer_cells, n_outer_cells, outer_cell_size, outer_cell_size),
-        input_files(FindInputFiles(input_dirs,file_name_pattern,
-                                   exclude_list, exclude_dir_list)),
+        input_files(file_name),
         hasData(false)
-    {
+    { 
+      ROOT::EnableThreadSafety();
       if(n_threads > 1) ROOT::EnableImplicitMT(n_threads);
 
-      // file = OpenRootFile(file_name);
+      // file = OpenRootFile(input_files.at(0));
       // tauTuple = std::make_shared<tau_tuple::TauTuple>(file.get(), true);
 
       std::cout << "Number of files to process: " << input_files.size() << std::endl;
@@ -187,6 +188,9 @@ public:
       MaxDisbCheck(hist_weights, weight_thr);
 
     }
+
+    DataLoader(const DataLoader&) = delete;
+    DataLoader& operator=(const DataLoader&) = delete;
 
     bool MoveNext() {
 


### PR DESCRIPTION
The following changes are implemented:

1. Spectrums are recalculated using SourceDesc with fixed _point_entry and _point_exit in contrast to option of calculating probability of pt-eta-tau_type rejection based on whole datagroup spectra (this option is left as an optional flag --refill-spectrum).
2. The exception-handling is added to catch an empty bins in pt-eta histogram (can be ignored with flag --enable-emptybin)
3. Config file for datagroup list is updated