### PR TITLE
Re-weighting by function.

### DIFF
--- a/Training/configs/training_v1.yaml
+++ b/Training/configs/training_v1.yaml
@@ -14,7 +14,16 @@ Setup:
     input_dir            : "<path_to_shuffle_and_merge_files>"
     input_spectrum       : "<path_to_shuffle_and_merge_spectrum>.root"
     target_spectrum      : "<path_to_shuffle_and_merge_spectrum>.root"
-    recompute_tautype    : True
+    # Target specrum formats:
+    # "hist" (basing on target histogram),
+    # "func" (basing on function),
+    # "func_i" (basing on function integrated within the bin)
+    target_format        : "func"
+    # target_function is valid for func || func_i cases
+    # example: "TMath::Exp(-0.01*x[0]*x[1])"
+    # where x[0] is pt-axis, x[1] is eta-axis
+    target_function      : "1.0"
+    recompute_tautype    : False
     weight_thr           : 100000.0
 
     # here define variables for the Histogram_2D class

--- a/Training/interface/DataLoader_main.h
+++ b/Training/interface/DataLoader_main.h
@@ -171,12 +171,8 @@ public:
       auto file_input = std::make_shared<TFile>(input_spectrum.c_str());
       auto file_target = std::make_shared<TFile>(target_spectrum.c_str());
 
-      Histogram_2D target_histogram("target", xaxis, ymin, ymax);
-      Histogram_2D input_histogram ("input" , xaxis, ymin, ymax);
-      for (int i = 0; i < yaxis_list.size(); i++){
-          target_histogram.add_y_binning_by_index(i, yaxis_list[i]);
-          input_histogram .add_y_binning_by_index(i, yaxis_list[i]);
-      }
+      Histogram_2D target_histogram("target", xaxis, yaxis_list, ymin, ymax);
+      Histogram_2D input_histogram ("input" , xaxis, yaxis_list, ymin, ymax);
 
       std::shared_ptr<TH2D> target_th2d = std::shared_ptr<TH2D>(dynamic_cast<TH2D*>(file_target->Get("eta_pt_hist_tau")));
       if (!target_th2d) throw std::runtime_error("Target histogram could not be loaded");

--- a/Training/interface/DataLoader_main.h
+++ b/Training/interface/DataLoader_main.h
@@ -4,6 +4,7 @@
 
 #include "TROOT.h"
 #include "TLorentzVector.h"
+#include "TMath.h" 
 
 #include "TauMLTools/Analysis/interface/TauSelection.h"
 #include "TauMLTools/Analysis/interface/AnalysisTypes.h"
@@ -192,7 +193,7 @@ public:
             ("w_1_"+tau_name).c_str()
         ));
 
-        hist_weights[tau_type]->Scale(input_th2d->Integral()/hist_weights[tau_type]->Integral());
+        hist_weights[tau_type]->Scale((input_th2d->Integral()/hist_weights[tau_type]->Integral()));
 
 
         target_histogram.reset();
@@ -201,7 +202,9 @@ public:
 
       // Balance tau types to tau_h (here we consider tau_type=2 for tau_h):
       for( auto const& [tau_type, tau_name] : tau_types_names) {
-        hist_weights[tau_type]->Scale(hist_weights[2]->Integral() / hist_weights[tau_type]->Integral());
+        hist_weights[tau_type]->Scale(
+            TMath::Power(hist_weights[2]->Integral() / hist_weights[tau_type]->Integral(), 2)
+          );
         
       }
       MaxDisbCheck(hist_weights, weight_thr);

--- a/Training/interface/histogram2d.h
+++ b/Training/interface/histogram2d.h
@@ -16,7 +16,9 @@ void load_axis_into_vector(const TAxis* axis, std::vector<double>& vector);
 
 class Histogram_2D{
   public:
-    Histogram_2D(const char* name, std::vector<double> xaxis, const double ymin, const double ymax);
+    Histogram_2D(const char* name, std::vector<double> xaxis,
+                 std::vector<std::vector<double>> yaxis_list,
+                 const double ymin, const double ymax);
     Histogram_2D(Histogram_2D& histo) = delete;
     ~Histogram_2D();
 
@@ -24,7 +26,6 @@ class Histogram_2D{
     void divide   (const Histogram_2D& histo);
     void reset();
 
-    void add_y_binning_by_index(const int index, const std::vector<double> yaxis);
 
     bool can_be_imported(const TH2D& histo);
     void print(const char* dir);
@@ -33,6 +34,8 @@ class Histogram_2D{
     TH2D& get_weights_th2d(const char* name, const char* title);
 
   private:
+    void add_y_binning_by_index(const int index, const std::vector<double> yaxis);
+    
     int find_bin_by_value_(const double& x);
 
     std::string name_;
@@ -49,7 +52,10 @@ class Histogram_2D{
 Histogram_2D::~Histogram_2D(){
 }
 
-Histogram_2D::Histogram_2D(const char* name, std::vector<double> xaxis, const double ymin, const double ymax){
+Histogram_2D::Histogram_2D(const char* name, std::vector<double> xaxis, 
+                           std::vector<std::vector<double>> yaxis_list,
+                           const double ymin, 
+                           const double ymax){
   xaxis_ = xaxis;
   for (std::vector<double>::iterator it = xaxis.begin(); it != std::prev(xaxis.end()); it++){
     xaxis_content_.push_back(std::make_shared<TH1D>());
@@ -57,6 +63,9 @@ Histogram_2D::Histogram_2D(const char* name, std::vector<double> xaxis, const do
   ymin_ = ymin;
   ymax_ = ymax;
   name_ = name;
+
+  for (int i = 0; i < yaxis_list.size(); i++)
+    add_y_binning_by_index(i, yaxis_list[i]);
 }
 
 void Histogram_2D::add_y_binning_by_index(const int index, const std::vector<double> yaxis){

--- a/Training/interface/histogram2d.h
+++ b/Training/interface/histogram2d.h
@@ -172,7 +172,6 @@ void Histogram_2D::th2d_add (const TH2D* histo_ptr){
 
 void Histogram_2D::th2d_add (const std::string function_string){
 
-  std::cout << "format: " << input_format <<std::endl;
   if(input_format!="func" && input_format!="func_i")
     throw std::invalid_argument("Corresponding object is not supposed to be run (Histogram_2D::th2d_add) with std::string");
 


### PR DESCRIPTION
Two options of re-weighting in DataLoader are added:
1) "func" - value in every bin of the target histogram is defined as the value of the function in the center of the bin.
2) "func_i" -  value is defined as an integral of the function within the corresponding bin. (In this case, target_function is density function)

After evaluation of weights, histogram is reweighed up to n_entries_i  of corresponding type and to take into account difference between amount of tau_types : (n_entries_tau / n_entries_i)**2