### PR TITLE
Update histogram2d class

### DIFF
--- a/Training/interface/histogram2d.h
+++ b/Training/interface/histogram2d.h
@@ -16,7 +16,7 @@ void load_axis_into_vector(const TAxis* axis, std::vector<double>& vector);
 
 class Histogram_2D{
   public:
-    Histogram_2D(const char* name, std::vector<double> xaxis, const double ymin, const double ymax);
+    Histogram_2D(const char* name, std::vector<double> yaxis, const double xmin, const double xmax);
     Histogram_2D(Histogram_2D& histo) = delete;
     ~Histogram_2D();
 
@@ -24,7 +24,7 @@ class Histogram_2D{
     void divide   (const Histogram_2D& histo);
     void reset();
 
-    void add_y_binning_by_index(const int index, const std::vector<double> yaxis);
+    void add_x_binning_by_index(const int index, const std::vector<double> xaxis);
 
     bool can_be_imported(const TH2D& histo);
     void print(const char* dir);
@@ -33,43 +33,43 @@ class Histogram_2D{
     TH2D& get_weights_th2d(const char* name, const char* title);
 
   private:
-    int find_bin_by_value_(const double& x);
+    int find_bin_by_value_(const double& y);
 
     std::string name_;
 
-    std::vector<double>                 xaxis_;
-    std::vector<std::shared_ptr<TH1D>>  xaxis_content_;
+    std::vector<double>                 yaxis_;
+    std::vector<std::shared_ptr<TH1D>>  yaxis_content_;
     std::vector<bool> occupancy_;
 
     std::shared_ptr<TH2D> histo_ = std::make_shared<TH2D>();
 
-    double ymin_ = std::numeric_limits<float>::max();
-    double ymax_ = std::numeric_limits<float>::lowest();
+    double xmin_ = std::numeric_limits<float>::max();
+    double xmax_ = std::numeric_limits<float>::lowest();
 };
 
 Histogram_2D::~Histogram_2D(){
 }
 
-Histogram_2D::Histogram_2D(const char* name, std::vector<double> xaxis, const double ymin, const double ymax){
-  xaxis_ = xaxis;
-  for (std::vector<double>::iterator it = xaxis.begin(); it != std::prev(xaxis.end()); it++){
-    xaxis_content_.push_back(std::make_shared<TH1D>());
+Histogram_2D::Histogram_2D(const char* name, std::vector<double> yaxis, const double xmin, const double xmax){
+  yaxis_ = yaxis;
+  for (std::vector<double>::iterator it = yaxis.begin(); it != std::prev(yaxis.end()); it++){
+    yaxis_content_.push_back(std::make_shared<TH1D>());
     occupancy_.push_back(false);
   }
-  ymin_ = ymin;
-  ymax_ = ymax;
+  xmin_ = xmin;
+  xmax_ = xmax;
   name_ = name;
 }
 
-void Histogram_2D::add_y_binning_by_index(const int index, const std::vector<double> yaxis){
+void Histogram_2D::add_x_binning_by_index(const int index, const std::vector<double> xaxis){
   std::string name = name_+std::to_string(index);
-  if(index >= xaxis_content_.size()){
-    std::runtime_error("Index "+std::to_string(index)+" out of x-axis range");
+  if(index >= yaxis_content_.size()){
+    std::runtime_error("Index "+std::to_string(index)+" out of y-axis range");
   }
-  if (yaxis.front() != ymax_ || yaxis.back() != ymin_){
+  if (xaxis.front() != xmax_ || xaxis.back() != xmin_){
     std::runtime_error("Input yaxis min or max values not matching specified min and max values");
   }
-  xaxis_content_[index] = std::shared_ptr<TH1D>(new TH1D(name.c_str(), "", yaxis.size()-1, &yaxis[0]));
+  yaxis_content_[index] = std::shared_ptr<TH1D>(new TH1D(name.c_str(), "", xaxis.size()-1, &xaxis[0]));
   occupancy_[index] = true;
 }
 
@@ -88,37 +88,33 @@ bool Histogram_2D::can_be_imported(const TH2D& histo){
 
   std::vector<double> input_xaxis;
   std::vector<double> input_yaxis;
-  std::vector<double> this_yaxis;
+  std::vector<double> this_xaxis;
 
-  //load_axis_into_vector(histo.GetXaxis(), input_xaxis);
-  //load_axis_into_vector(histo.GetYaxis(), input_yaxis);
-  // WORKAROUND to switch x and y axes
-  std::cout << "WARNING from can_be_imported: x and y axes are switched!" << std::endl;
-  load_axis_into_vector(histo.GetYaxis(), input_xaxis);
-  load_axis_into_vector(histo.GetXaxis(), input_yaxis);
+  load_axis_into_vector(histo.GetXaxis(), input_xaxis);
+  load_axis_into_vector(histo.GetYaxis(), input_yaxis);
 
-  if (!check_axis(input_xaxis, xaxis_)){
-    std::cerr << "Invalid x-axis binning found" << std::endl;
+  if (!check_axis(input_yaxis, yaxis_)){
+    std::cerr << "Invalid y-axis binning found" << std::endl;
     return false;
   }
 
-  for(int ix = 0; ix < xaxis_.size()-1; ix++){
-    auto this_histo = xaxis_content_[ix];
-    load_axis_into_vector(this_histo->GetXaxis(), this_yaxis);
-    if(!check_axis(input_yaxis, this_yaxis)){
-      std::cerr << "Invalid y axis binning found for x bin n. " << ix << std::endl;
+  for(int iy = 0; iy < yaxis_.size()-1; iy++){
+    auto this_histo = yaxis_content_[iy];
+    load_axis_into_vector(this_histo->GetXaxis(), this_xaxis);
+    if(!check_axis(input_xaxis, this_xaxis)){
+      std::cerr << "Invalid x axis binning found for y bin n. " << iy << std::endl;
       return false;
     }
-    this_yaxis.clear();
+    this_xaxis.clear();
   }
   return true;
 }
 
-int Histogram_2D::find_bin_by_value_(const double& x){
-  for(int ix = 0; ix < xaxis_.size() - 1; ix++){
-    if(x >= xaxis_[ix] && x < xaxis_[ix+1]) return ix;
+int Histogram_2D::find_bin_by_value_(const double& y){
+  for(int iy = 0; iy < yaxis_.size() - 1; iy++){
+    if(y >= yaxis_[iy] && y < yaxis_[iy+1]) return iy;
   }
-  throw std::range_error("Value "+std::to_string(x)+" is not in the range of the x axis");
+  throw std::range_error("Value "+std::to_string(y)+" is not in the range of the y axis");
 }
 
 void Histogram_2D::th2d_add (const TH2D& histo){
@@ -126,26 +122,20 @@ void Histogram_2D::th2d_add (const TH2D& histo){
     throw std::invalid_argument("Given TH2D "+std::string(histo.GetName())+" can not be imported");
   }
 
-  //auto input_yaxis = histo.GetYaxis();
-  //auto input_xaxis = histo.GetXaxis();
-  // WORKAROUND to switch x and y axes
-  std::cout << "WARNING from th2d_add: x and y axes are switched!" << std::endl;
-  auto input_yaxis = histo.GetXaxis();
-  auto input_xaxis = histo.GetYaxis();
+  auto input_yaxis = histo.GetYaxis();
+  auto input_xaxis = histo.GetXaxis();
 
   for (int iy = 1; iy <= input_yaxis->GetNbins(); iy++){
   for (int ix = 1; ix <= input_xaxis->GetNbins(); ix++){
     auto bincy = input_yaxis->GetBinCenter(iy);
     auto bincx = input_xaxis->GetBinCenter(ix);
 
-    if(bincy < ymin_ || bincy >= ymax_ || bincx < xaxis_.front() || bincx >= xaxis_.back()) continue;
+    if(bincx < xmin_ || bincx >= xmax_ || bincy < yaxis_.front() || bincy >= yaxis_.back()) continue;
 
-    auto yhisto = xaxis_content_[find_bin_by_value_(bincx)];
-    yhisto->SetBinContent(
-      yhisto->FindBin(bincy), 
-      //yhisto->GetBinContent(yhisto->FindBin(bincy)) + histo.GetBinContent(ix, iy));
-      // WORKAROUND to switch x and y axes
-      yhisto->GetBinContent(yhisto->FindBin(bincy)) + histo.GetBinContent(iy, ix));
+    auto xhisto = yaxis_content_[find_bin_by_value_(bincy)];
+    xhisto->SetBinContent(
+      xhisto->FindBin(bincx),
+      xhisto->GetBinContent(xhisto->FindBin(bincx)) + histo.GetBinContent(ix, iy));
   }}
 }
 
@@ -157,25 +147,25 @@ void Histogram_2D::divide(const Histogram_2D& histo){
   if (!std::all_of(occupancy_.begin(), occupancy_.end(), [](bool i){return i;})){
     throw std::logic_error("Not all the bins have been initialized");
   }
-  if (!check_axis(xaxis_, histo.xaxis_)){
+  if (!check_axis(yaxis_, histo.yaxis_)){
     throw std::logic_error("Invalid x binning detected on denominator for Histogram_2D "+histo.name_);
   }
   
-  std::vector<double> thisyaxis;
-  std::vector<double> yaxis;
-  for (int ix = 0; ix < xaxis_content_.size(); ix++){
-    TH1D* thisyhisto = xaxis_content_[ix].get();
-    TH1D* yhisto     = histo.xaxis_content_[ix].get();
-    load_axis_into_vector(thisyhisto->GetXaxis(), thisyaxis);
-    load_axis_into_vector(yhisto->GetXaxis()    , yaxis    );
+  std::vector<double> thisxaxis;
+  std::vector<double> xaxis;
+  for (int iy = 0; iy < yaxis_content_.size(); iy++){
+    TH1D* thisxhisto = yaxis_content_[iy].get();
+    TH1D* xhisto     = histo.yaxis_content_[iy].get();
+    load_axis_into_vector(thisxhisto->GetXaxis(), thisxaxis);
+    load_axis_into_vector(xhisto->GetXaxis()    , xaxis    );
 
-    if(!check_axis(thisyaxis, yaxis)){
-      throw std::logic_error("Invalid y-axis binning found for denominator in x bin n. "+std::to_string(ix)+" for Histogram_2D "+histo.name_);
+    if(!check_axis(thisxaxis, xaxis)){
+      throw std::logic_error("Invalid x-axis binning found for denominator in y bin n. "+std::to_string(iy)+" for Histogram_2D "+histo.name_);
     }
 
-    thisyhisto->Sumw2();
-    yhisto->Sumw2();
-    (*thisyhisto).Divide(yhisto);
+    thisxhisto->Sumw2();
+    xhisto->Sumw2();
+    (*thisxhisto).Divide(xhisto);
   }
 }
 
@@ -187,40 +177,32 @@ TH2D& Histogram_2D::get_weights_th2d(const char* name, const char* title){
     for (int i = 0; i < vector.size()-1; i++) min = std::min(min, vector[i+1] - vector[i]);
   };
 
-  get_min_width(xaxis_, xwidthmin);
+  get_min_width(yaxis_, ywidthmin);
 
-  std::vector<double> yaxis;
-  for (int ix = 0; ix < xaxis_content_.size(); ix++){
-    auto yhisto = xaxis_content_[ix];
-    load_axis_into_vector(yhisto->GetXaxis(), yaxis);
-    get_min_width(yaxis, ywidthmin);
-    yaxis.clear();
+  std::vector<double> xaxis;
+  for (int iy = 0; iy < yaxis_content_.size(); iy++){
+    auto xhisto = yaxis_content_[iy];
+    load_axis_into_vector(xhisto->GetXaxis(), xaxis);
+    get_min_width(xaxis, xwidthmin);
+    xaxis.clear();
   }
 
-  int nx = (xaxis_.back() - xaxis_.front()) / xwidthmin;
-  int ny = (ymax_ - ymin_) / ywidthmin;
+  int ny = (yaxis_.back() - yaxis_.front()) / ywidthmin;
+  int nx = (xmax_ - xmin_) / xwidthmin;
 
-  //histo_ = std::shared_ptr<TH2D>(new TH2D(name, title, nx, xaxis_.front(), xaxis_.back(), ny, ymin_, ymax_));
-  // WORKAROUND to switch x and y axes
-  std::cout << "WARNING from get_weights_th2d: x and y axes are switched!" << std::endl;
-  histo_ = std::shared_ptr<TH2D>(new TH2D(name, title, ny, ymin_, ymax_, nx, xaxis_.front(), xaxis_.back()));
+  histo_ = std::shared_ptr<TH2D>(new TH2D(name, title, nx, xmin_, xmax_, ny, yaxis_.front(), yaxis_.back()));
 
   for(int iy = 1; iy <= ny; iy++){
   for(int ix = 1; ix <= nx; ix++){
-    //double bincx = histo_->GetXaxis()->GetBinCenter(ix);
-    //double bincy = histo_->GetYaxis()->GetBinCenter(iy);
-    // WORKAROUND to switch x and y axess
-    double bincx = histo_->GetYaxis()->GetBinCenter(ix);
-    double bincy = histo_->GetXaxis()->GetBinCenter(iy);
+    double bincx = histo_->GetXaxis()->GetBinCenter(ix);
+    double bincy = histo_->GetYaxis()->GetBinCenter(iy);
 
-    auto yhisto    = xaxis_content_[find_bin_by_value_(bincx)];
-    double content = yhisto->GetBinContent(yhisto->FindBin(bincy));
-    double error   = yhisto->GetBinError(yhisto->FindBin(bincy));
+    auto xhisto    = yaxis_content_[find_bin_by_value_(bincy)];
+    double content = xhisto->GetBinContent(xhisto->FindBin(bincx));
+    double error   = xhisto->GetBinError(xhisto->FindBin(bincx));
 
-    //histo_->SetBinContent(ix, iy, content);
-    // WORKAROUND to switch x and y axess
-    histo_->SetBinContent(iy, ix, content);
-    histo_->SetBinError  (iy, ix, error  );
+    histo_->SetBinContent(ix, iy, content);
+    histo_->SetBinError  (ix, iy, error  );
   }}
 
   return *histo_;
@@ -228,17 +210,18 @@ TH2D& Histogram_2D::get_weights_th2d(const char* name, const char* title){
 
 void Histogram_2D::print(const char* dir){
   TCanvas can;
-  for(int ix = 0; ix < xaxis_content_.size(); ix++){
-    auto yhisto = xaxis_content_[ix]; 
-    std::string name = std::string(dir)+"/"+yhisto->GetName()+".pdf";
+  for(int iy = 0; iy < yaxis_content_.size(); iy++){
+    auto xhisto = yaxis_content_[iy];
+    std::string name = std::string(dir)+"/"+xhisto->GetName()+".pdf";
+    xhisto->Draw("HIST");
     can.SaveAs(name.c_str(), "pdf");
   }
 }
 
 void Histogram_2D::reset(){
-  for (int ix = 0; ix < xaxis_content_.size(); ix++){
-    auto yhisto = xaxis_content_[ix].get();
-    yhisto->Reset();
+  for (int iy = 0; iy < yaxis_content_.size(); iy++){
+    auto xhisto = yaxis_content_[iy].get();
+    xhisto->Reset();
   }
 }
 

--- a/Training/interface/histogram2d.h
+++ b/Training/interface/histogram2d.h
@@ -39,6 +39,7 @@ class Histogram_2D{
 
     std::vector<double>                 xaxis_;
     std::vector<std::shared_ptr<TH1D>>  xaxis_content_;
+    std::vector<bool> occupancy_;
 
     std::shared_ptr<TH2D> histo_ = std::make_shared<TH2D>();
 
@@ -53,6 +54,7 @@ Histogram_2D::Histogram_2D(const char* name, std::vector<double> xaxis, const do
   xaxis_ = xaxis;
   for (std::vector<double>::iterator it = xaxis.begin(); it != std::prev(xaxis.end()); it++){
     xaxis_content_.push_back(std::make_shared<TH1D>());
+    occupancy_.push_back(false);
   }
   ymin_ = ymin;
   ymax_ = ymax;
@@ -68,6 +70,7 @@ void Histogram_2D::add_y_binning_by_index(const int index, const std::vector<dou
     std::runtime_error("Input yaxis min or max values not matching specified min and max values");
   }
   xaxis_content_[index] = std::shared_ptr<TH1D>(new TH1D(name.c_str(), "", yaxis.size()-1, &yaxis[0]));
+  occupancy_[index] = true;
 }
 
 bool Histogram_2D::can_be_imported(const TH2D& histo){
@@ -151,6 +154,9 @@ void Histogram_2D::divide(const Histogram_2D& histo){
     return axis1 == axis2;
   };
 
+  if (!std::all_of(occupancy_.begin(), occupancy_.end(), [](bool i){return i;})){
+    throw std::logic_error("Not all the bins have been initialized");
+  }
   if (!check_axis(xaxis_, histo.xaxis_)){
     throw std::logic_error("Invalid x binning detected on denominator for Histogram_2D "+histo.name_);
   }

--- a/Training/interface/histogram2d.h
+++ b/Training/interface/histogram2d.h
@@ -164,8 +164,8 @@ void Histogram_2D::divide(const Histogram_2D& histo){
   std::vector<double> thisyaxis;
   std::vector<double> yaxis;
   for (int ix = 0; ix < xaxis_content_.size(); ix++){
-    auto thisyhisto = xaxis_content_[ix];
-    auto yhisto     = histo.xaxis_content_[ix];
+    TH1D* thisyhisto = xaxis_content_[ix].get();
+    TH1D* yhisto     = histo.xaxis_content_[ix].get();
     load_axis_into_vector(thisyhisto->GetXaxis(), thisyaxis);
     load_axis_into_vector(yhisto->GetXaxis()    , yaxis    );
 
@@ -173,7 +173,9 @@ void Histogram_2D::divide(const Histogram_2D& histo){
       throw std::logic_error("Invalid y-axis binning found for denominator in x bin n. "+std::to_string(ix)+" for Histogram_2D "+histo.name_);
     }
 
-    (*thisyhisto).Divide(yhisto.get());
+    thisyhisto->Sumw2();
+    yhisto->Sumw2();
+    (*thisyhisto).Divide(yhisto);
   }
 }
 
@@ -213,10 +215,12 @@ TH2D& Histogram_2D::get_weights_th2d(const char* name, const char* title){
 
     auto yhisto    = xaxis_content_[find_bin_by_value_(bincx)];
     double content = yhisto->GetBinContent(yhisto->FindBin(bincy));
+    double error   = yhisto->GetBinError(yhisto->FindBin(bincy));
 
     //histo_->SetBinContent(ix, iy, content);
     // WORKAROUND to switch x and y axess
     histo_->SetBinContent(iy, ix, content);
+    histo_->SetBinError  (iy, ix, error  );
   }}
 
   return *histo_;


### PR DESCRIPTION
This PR updates the histogram2D class:
- x and y axes now have the correct behaviour (I removed the workaround): x binning is a function of y
- throw an exception if not all the y bins have been assigned to a custom x binning with the add_x_binning_by_index method. Untill now, a default single-bin TH1D was instanced for each y bin, giving rise to possibly unseen issues
- correctly compute weights when the divide method is called (using Sumw2()) and when the TH2D is exported