### PR TITLE
Fix of few DataLoader interface bugs

### DIFF
--- a/Training/python/DataLoader.py
+++ b/Training/python/DataLoader.py
@@ -19,13 +19,14 @@ class QueueEx:
     def __init__(self, max_size=0, max_n_puts=math.inf):
         self.n_puts = mp.Value('i', 0)
         self.max_n_puts = max_n_puts
+        if self.max_n_puts < 0:
+            self.max_n_puts = math.inf
         self.mp_queue = mp.Queue(max_size)
 
     def put(self, item, retry_interval=0.3):
         while True:
             with self.n_puts.get_lock():
-                if self.n_puts.value >= self.max_n_puts and \
-                   self.max_n_puts != -1:
+                if self.n_puts.value >= self.max_n_puts:
                     return False
                 try:
                     self.mp_queue.put(item, False)

--- a/Training/python/DataLoader.py
+++ b/Training/python/DataLoader.py
@@ -185,12 +185,7 @@ class DataLoader:
 
         self.train_files, self.val_files = \
              np.split(data_files, [int(len(data_files)*(1-self.validation_split))])
-            
-        if len(self.train_files) == 0:
-            raise RuntimeError("Taining file queue is empty.")
-        if len(self.val_files) == 0:
-            raise RuntimeError("Validation file queue is empty.")
-
+             
         print("Files for training:", len(self.train_files))
         print("Files for validation:", len(self.val_files))
 
@@ -198,6 +193,10 @@ class DataLoader:
     def get_generator(self, primary_set = True, return_truth = True, return_weights = False):
 
         _files = self.train_files if primary_set else self.val_files
+        if len(_files)==0:
+            raise RuntimeError(("Taining" if primary_set else "Validation")+\
+                               " file list is empty.")
+
         n_batches = self.n_batches if primary_set else self.n_batches_val
         print("Number of workers in DataLoader: ", self.n_load_workers)
 

--- a/Training/python/DataLoader.py
+++ b/Training/python/DataLoader.py
@@ -24,7 +24,8 @@ class QueueEx:
     def put(self, item, retry_interval=0.3):
         while True:
             with self.n_puts.get_lock():
-                if self.n_puts.value >= self.max_n_puts:
+                if self.n_puts.value >= self.max_n_puts and \
+                   self.max_n_puts != -1:
                     return False
                 try:
                     self.mp_queue.put(item, False)
@@ -185,7 +186,7 @@ class DataLoader:
 
         self.train_files, self.val_files = \
              np.split(data_files, [int(len(data_files)*(1-self.validation_split))])
-             
+
         print("Files for training:", len(self.train_files))
         print("Files for validation:", len(self.val_files))
 


### PR DESCRIPTION
1) fix bug with n_batches=-1 case
2) add opportunity to run with validation_split=0 to enable easy prediction evaluation on fixed datafiles
3) *there was bug with input queue_files in the case when we have a lot of files, but I can not reproduce this bug at the moment. Any ideas? (buffer error expected)

thanks @yaourtpourtoi for reporting about the bugs.