### PR TITLE
Global grid features

### DIFF
--- a/Training/configs/ShuffleMergeSpectral_trainingSamples-2_files_0_50.json
+++ b/Training/configs/ShuffleMergeSpectral_trainingSamples-2_files_0_50.json
@@ -345,6 +345,40 @@
             }
         }
     },
+    "GridGlobalFeatures": {
+        "rho": {
+            "global": {
+                "mean": 25,
+                "std": 25,
+                "lim_min": "-1",
+                "lim_max": "1"
+            }
+        },
+        "tau_pt": {
+            "global": {
+                "mean": 510.0,
+                "std": 490.0,
+                "lim_min": -1.0,
+                "lim_max": 1.0
+            }
+        },
+        "tau_eta": {
+            "global": {
+                "mean": 0.0,
+                "std": 2.3,
+                "lim_min": -1.0,
+                "lim_max": 1.0
+            }
+        },
+        "tau_inside_ecal_crack": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf"
+            }
+        }
+    },
     "PfCand_electron": {
         "pfCand_ele_valid": {
             "global": {

--- a/Training/configs/ShuffleMergeSpectral_trainingSamples-2_files_0_50.json
+++ b/Training/configs/ShuffleMergeSpectral_trainingSamples-2_files_0_50.json
@@ -345,7 +345,7 @@
             }
         }
     },
-    "GridGlobalFeatures": {
+    "GridGlobal": {
         "rho": {
             "global": {
                 "mean": 25,

--- a/Training/configs/scaling_params_v1.json
+++ b/Training/configs/scaling_params_v1.json
@@ -1,4 +1,38 @@
 {
+    "GridGlobalFeatures": {
+        "rho": {
+            "global": {
+                "mean": 25,
+                "std": 25,
+                "lim_min": "-1",
+                "lim_max": "1"
+            }
+        },
+        "tau_pt": {
+            "global": {
+                "mean": 510.0,
+                "std": 490.0,
+                "lim_min": -1.0,
+                "lim_max": 1.0
+            }
+        },
+        "tau_eta": {
+            "global": {
+                "mean": 0.0,
+                "std": 2.3,
+                "lim_min": -1.0,
+                "lim_max": 1.0
+            }
+        },
+        "tau_inside_ecal_crack": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf"
+            }
+        }
+    },
     "TauFlat": {
         "tau_pt": {
             "global": {

--- a/Training/configs/scaling_params_v1.json
+++ b/Training/configs/scaling_params_v1.json
@@ -1,5 +1,5 @@
 {
-    "GridGlobalFeatures": {
+    "GridGlobal": {
         "rho": {
             "global": {
                 "mean": 25,

--- a/Training/configs/training_v1.yaml
+++ b/Training/configs/training_v1.yaml
@@ -11,9 +11,9 @@ Setup:
     # tau_types_names.keys are written in accordance with tauType in the tau tuple
     tau_types_names      : { "0":"e", "1":"mu", "2":"tau", "3":"jet" }
     recompute_tautype    : True
-    input_dir            : "/eos/cms/store/group/phys_tau/TauML/prod_2018_v2/ShuffleMergeSpectral_trainingSamples-2/"
-    input_spectrum       : "/eos/cms/store/group/phys_tau/TauML/prod_2018_v2/ShuffleMergeSpectral_TrainingSpectrum/ShuffleMergeSpectral_trainingSamples-2_spectrum.root"
-    target_spectrum      : "/eos/cms/store/group/phys_tau/TauML/prod_2018_v2/ShuffleMergeSpectral_TrainingSpectrum/ShuffleMergeSpectral_trainingSamples-2_spectrum.root"
+    input_dir            : "/nfs/dust/cms/user/mykytaua/dataDeepTau/DeepTauTraining/ShuffleMergeSpectral_trainingSamples-2/"
+    input_spectrum       : "/nfs/dust/cms/user/mykytaua/dataDeepTau/DeepTauTraining/ShuffleMergeSpectral_TrainingSpectrum/ShuffleMergeSpectral_trainingSamples-2_spectrum.root"
+    target_spectrum      : "/nfs/dust/cms/user/mykytaua/dataDeepTau/DeepTauTraining/ShuffleMergeSpectral_TrainingSpectrum/ShuffleMergeSpectral_trainingSamples-2_spectrum.root"
     weight_thr           : 100000.0
 
     # here define variables for the Histogram_2D class
@@ -79,6 +79,7 @@ SetupNN:
     dense_net            : { "activation": "PReLU", "dropout_rate": 0.2, "reduction_rate": 1, "first_layer_width": 200, "last_layer_width": 200, "min_n_layers": 4 }
 
 CellObjectType : [
+                 GridGlobalFeatures,
                  PfCand_electron,
                  PfCand_muon,
                  PfCand_chHad,
@@ -149,6 +150,12 @@ Scaling_setup:
       TauFlat:
         var_names: # used to derive dR selection query
           pt: tau_pt
+          eta: tau_eta
+          phi: tau_phi
+        cone_types: [null] # [null] in case of no split into cones (i.e. inclusive computation)
+      # ----------------------------
+      GridGlobalFeatures:
+        var_names: # used to derive dR selection query
           eta: tau_eta
           phi: tau_phi
         cone_types: [null] # [null] in case of no split into cones (i.e. inclusive computation)
@@ -262,6 +269,12 @@ Features_all :
                 - tau_emFraction: [null, null, "linear", -1., 1.]
                 - tau_inside_ecal_crack: [null, null, "no_scaling"]
                 - tau_leadChargedCand_etaAtEcalEntrance_minus_tau_eta: [null, {"tau_leadChargedCand_etaAtEcalEntrance_minus_tau_eta": "tau_leadChargedCand_etaAtEcalEntrance - tau_eta"}, "normal", -5, 5]
+    
+    GridGlobalFeatures:
+                - rho: [null, null, "linear", 0, 50]
+                - tau_pt: [null, null, "linear", 20, 1000]
+                - tau_eta: [null, null, "linear", -2.3, 2.3]
+                - tau_inside_ecal_crack: [null, null, "no_scaling"]
 
     PfCand_electron :
                 - pfCand_ele_valid: [*is_pfElectron, null, "no_scaling"]
@@ -455,6 +468,7 @@ Features_all :
 
 Features_disable :
     TauFlat : ["tau_phi"]
+    GridGlobalFeatures : []
     PfCand_electron : [ ]
     PfCand_muon : [ ]
     PfCand_chHad : [ ]

--- a/Training/configs/training_v1.yaml
+++ b/Training/configs/training_v1.yaml
@@ -11,9 +11,9 @@ Setup:
     # tau_types_names.keys are written in accordance with tauType in the tau tuple
     tau_types_names      : { "0":"e", "1":"mu", "2":"tau", "3":"jet" }
     recompute_tautype    : True
-    input_dir            : "/nfs/dust/cms/user/mykytaua/dataDeepTau/DeepTauTraining/ShuffleMergeSpectral_trainingSamples-2/"
-    input_spectrum       : "/nfs/dust/cms/user/mykytaua/dataDeepTau/DeepTauTraining/ShuffleMergeSpectral_TrainingSpectrum/ShuffleMergeSpectral_trainingSamples-2_spectrum.root"
-    target_spectrum      : "/nfs/dust/cms/user/mykytaua/dataDeepTau/DeepTauTraining/ShuffleMergeSpectral_TrainingSpectrum/ShuffleMergeSpectral_trainingSamples-2_spectrum.root"
+    input_dir            : "/eos/cms/store/group/phys_tau/TauML/prod_2018_v2/ShuffleMergeSpectral_trainingSamples-2/"
+    input_spectrum       : "/eos/cms/store/group/phys_tau/TauML/prod_2018_v2/ShuffleMergeSpectral_TrainingSpectrum/ShuffleMergeSpectral_trainingSamples-2_spectrum.root"
+    target_spectrum      : "/eos/cms/store/group/phys_tau/TauML/prod_2018_v2/ShuffleMergeSpectral_TrainingSpectrum/ShuffleMergeSpectral_trainingSamples-2_spectrum.root"
     weight_thr           : 100000.0
 
     # here define variables for the Histogram_2D class
@@ -65,9 +65,9 @@ SetupNN:
     max_queue_size       : 20
     n_load_workers       : 4
     input_grids          : [
-                            [ PfCand_electron, PfCand_gamma, Electron ], # e-gamma
-                            [ PfCand_muon, Muon ], # muons
-                            [ PfCand_chHad, PfCand_nHad ] # hadrons
+                            [ GridGlobal, PfCand_electron, PfCand_gamma, Electron ], # e-gamma
+                            [ GridGlobal, PfCand_muon, Muon ], # muons
+                            [ GridGlobal, PfCand_chHad, PfCand_nHad ] # hadrons
                            ]
     TauLossesSFs         : [1, 2.5, 5, 1.5]
     optimizer_name       : "Nadam"

--- a/Training/configs/training_v1.yaml
+++ b/Training/configs/training_v1.yaml
@@ -79,7 +79,7 @@ SetupNN:
     dense_net            : { "activation": "PReLU", "dropout_rate": 0.2, "reduction_rate": 1, "first_layer_width": 200, "last_layer_width": 200, "min_n_layers": 4 }
 
 CellObjectType : [
-                 GridGlobalFeatures,
+                 GridGlobal,
                  PfCand_electron,
                  PfCand_muon,
                  PfCand_chHad,
@@ -154,7 +154,7 @@ Scaling_setup:
           phi: tau_phi
         cone_types: [null] # [null] in case of no split into cones (i.e. inclusive computation)
       # ----------------------------
-      GridGlobalFeatures:
+      GridGlobal:
         var_names: # used to derive dR selection query
           eta: tau_eta
           phi: tau_phi
@@ -270,7 +270,7 @@ Features_all :
                 - tau_inside_ecal_crack: [null, null, "no_scaling"]
                 - tau_leadChargedCand_etaAtEcalEntrance_minus_tau_eta: [null, {"tau_leadChargedCand_etaAtEcalEntrance_minus_tau_eta": "tau_leadChargedCand_etaAtEcalEntrance - tau_eta"}, "normal", -5, 5]
     
-    GridGlobalFeatures:
+    GridGlobal:
                 - rho: [null, null, "linear", 0, 50]
                 - tau_pt: [null, null, "linear", 20, 1000]
                 - tau_eta: [null, null, "linear", -2.3, 2.3]
@@ -468,7 +468,7 @@ Features_all :
 
 Features_disable :
     TauFlat : ["tau_phi"]
-    GridGlobalFeatures : []
+    GridGlobal : []
     PfCand_electron : [ ]
     PfCand_muon : [ ]
     PfCand_chHad : [ ]

--- a/Training/interface/DataLoader_main.h
+++ b/Training/interface/DataLoader_main.h
@@ -101,13 +101,14 @@ struct Data {
     typedef std::unordered_map<CellObjectType, std::unordered_map<bool, std::vector<float>>> GridMap;
 
     Data(size_t n_tau, size_t tau_fn, size_t n_inner_cells,
-         size_t n_outer_cells, size_t pfelectron_fn, size_t pfmuon_fn,
+         size_t n_outer_cells, size_t globalgrid_fn, size_t pfelectron_fn, size_t pfmuon_fn,
          size_t pfchargedhad_fn, size_t pfneutralhad_fn, size_t pfgamma_fn,
          size_t electron_fn, size_t muon_fn, size_t tau_labels) :
          x_tau(n_tau * tau_fn, 0), weight(n_tau, 0), y_onehot(n_tau * tau_labels, 0)
          {
-          // pf electron
-           // x_grid[CellObjectType::PfCand_electron][0] = std::vector<float>(n_tau * n_outer_cells * n_outer_cells * pfelectron_fn,0);
+           x_grid[CellObjectType::GridGlobal][0].resize(n_tau * n_outer_cells * n_outer_cells * globalgrid_fn,0);
+           x_grid[CellObjectType::GridGlobal][1].resize(n_tau * n_inner_cells * n_inner_cells * globalgrid_fn,0);
+           // pf electron
            x_grid[CellObjectType::PfCand_electron][0].resize(n_tau * n_outer_cells * n_outer_cells * pfelectron_fn,0);
            x_grid[CellObjectType::PfCand_electron][1].resize(n_tau * n_inner_cells * n_inner_cells * pfelectron_fn,0);
            // pf muons
@@ -221,7 +222,7 @@ public:
           throw std::runtime_error("TauTuple is not loaded!");
 
         if(!hasData) {
-          data = std::make_unique<Data>(n_tau, n_TauFlat, n_inner_cells, n_outer_cells,
+          data = std::make_unique<Data>(n_tau, n_TauFlat, n_inner_cells, n_outer_cells, n_GridGlobal,
                                         n_PfCand_electron, n_PfCand_muon, n_PfCand_chHad, n_PfCand_nHad,
                                         n_PfCand_gamma, n_Electron, n_Muon, tau_types_names.size()
                                         );
@@ -478,6 +479,13 @@ public:
                 }
             }
         };
+        { // CellObjectType::GridGlobal
+            typedef GridGlobal_Features Br;
+            fillGrid(Br::rho, tau.rho);
+            fillGrid(Br::tau_pt, tau.tau_pt);
+            fillGrid(Br::tau_eta, tau.tau_eta);
+            fillGrid(Br::tau_inside_ecal_crack, tau.tau_inside_ecal_crack);
+        }
 
         { // CellObjectType::PfCand_electron
 

--- a/Training/python/DataLoader.py
+++ b/Training/python/DataLoader.py
@@ -324,6 +324,7 @@ class DataLoader:
 
         # copy of feature lists is not necessery
         input_tau_branches = self.get_branches(self.config,"TauFlat")
+        input_cell_external_branches = self.get_branches(self.config,"GridGlobal")
         input_cell_pfCand_ele_branches = self.get_branches(self.config,"PfCand_electron")
         input_cell_pfCand_muon_branches = self.get_branches(self.config,"PfCand_muon")
         input_cell_pfCand_chHad_branches = self.get_branches(self.config,"PfCand_chHad")
@@ -345,9 +346,9 @@ class DataLoader:
         netConf.cell_locations = ['inner', 'outer']
         netConf.comp_names = ['egamma', 'muon', 'hadrons']
         netConf.n_comp_branches = [
-            len(input_cell_pfCand_ele_branches + input_cell_ele_branches + input_cell_pfCand_gamma_branches),
-            len(input_cell_pfCand_muon_branches + input_cell_muon_branches),
-            len(input_cell_pfCand_chHad_branches + input_cell_pfCand_nHad_branches)
+            len(input_cell_external_branches + input_cell_pfCand_ele_branches + input_cell_ele_branches + input_cell_pfCand_gamma_branches),
+            len(input_cell_external_branches + input_cell_pfCand_muon_branches + input_cell_muon_branches),
+            len(input_cell_external_branches + input_cell_pfCand_chHad_branches + input_cell_pfCand_nHad_branches)
         ]
         netConf.n_cells = self.n_cells
         netConf.n_outputs = self.tau_types

--- a/Training/python/DataLoader_test.py
+++ b/Training/python/DataLoader_test.py
@@ -14,9 +14,9 @@ print("Compiling Setup classes...")
 
 with open(os.path.abspath( "../configs/training_v1.yaml")) as f:
     config = yaml.safe_load(f)
-R.gInterpreter.Declare(config_parse.create_scaling_input("../configs/scaling_params_v1.json", config, verbose=True))
-R.gInterpreter.Declare(config_parse.create_settings(config, verbose=True))
-exit()
+R.gInterpreter.Declare(config_parse.create_scaling_input("../configs/scaling_params_v1.json", config, verbose=False))
+R.gInterpreter.Declare(config_parse.create_settings(config, verbose=False))
+
 print("Compiling DataLoader_main...")
 R.gInterpreter.Declare('#include "../interface/DataLoader_main.h"')
 R.gInterpreter.Declare('#include "TauMLTools/Core/interface/exception.h"')

--- a/Training/python/DataLoader_test.py
+++ b/Training/python/DataLoader_test.py
@@ -25,6 +25,7 @@ n_tau          = R.Setup.n_tau
 n_inner_cells  = R.Setup.n_inner_cells
 n_outer_cells  = R.Setup.n_outer_cells
 n_fe_tau    = R.Setup.n_TauFlat
+n_gridglob  = R.Setup.n_GridGlobal
 n_pf_el     = R.Setup.n_PfCand_electron
 n_pf_mu     = R.Setup.n_PfCand_muon
 n_pf_chHad  = R.Setup.n_PfCand_chHad
@@ -36,6 +37,7 @@ tau_types   = R.Setup.tau_types_names.size()
 input_files = glob(f'{R.Setup.input_dir}*.root')
 
 n_grid_features = {
+    "GridGlobal" : n_gridglob,
     "PfCand_electron" : n_pf_el,
     "PfCand_muon" : n_pf_mu,
     "PfCand_chHad" : n_pf_chHad,
@@ -45,7 +47,9 @@ n_grid_features = {
     "Muon" : n_muon
 }
 
-input_grids =[ [ "PfCand_electron", "PfCand_gamma", "Electron" ], [ "PfCand_muon", "Muon" ], [ "PfCand_chHad", "PfCand_nHad" ] ]
+input_grids =[ [ "GridGlobal", "PfCand_electron", "PfCand_gamma", "Electron" ],
+               [ "GridGlobal", "PfCand_muon", "Muon" ],
+               [ "GridGlobal", "PfCand_chHad", "PfCand_nHad" ] ]
 
 input_files = []
 for root, dirs, files in os.walk(os.path.abspath(R.Setup.input_dir)):

--- a/Training/python/DataLoader_test.py
+++ b/Training/python/DataLoader_test.py
@@ -5,15 +5,18 @@ import numpy as np
 import time
 import config_parse
 import os
+import yaml
 from glob import glob
 
 R.gROOT.ProcessLine(".include ../../..")
 
 print("Compiling Setup classes...")
 
-R.gInterpreter.Declare(config_parse.create_scaling_input("../configs/scaling_params_v1.json", "../configs/training_v1.yaml", verbose=False))
-R.gInterpreter.Declare(config_parse.create_settings("../configs/training_v1.yaml", verbose=False))
-
+with open(os.path.abspath( "../configs/training_v1.yaml")) as f:
+    config = yaml.safe_load(f)
+R.gInterpreter.Declare(config_parse.create_scaling_input("../configs/scaling_params_v1.json", config, verbose=True))
+R.gInterpreter.Declare(config_parse.create_settings(config, verbose=True))
+exit()
 print("Compiling DataLoader_main...")
 R.gInterpreter.Declare('#include "../interface/DataLoader_main.h"')
 R.gInterpreter.Declare('#include "TauMLTools/Core/interface/exception.h"')


### PR DESCRIPTION
In this PR the following changes were implemented:
1. Added Cell Object type to *.yaml
2. Checked that config_parse to correctly generate c++ classes
3. Modified c++ dataloader part
4. Check consistency with feature_scaling.py
5. Modify dataloader python part and Training.py to correctly handle **feature_scaling.py** tensor.

**in the modified input tensor `GridGlobal` features are added to the electromagnetic, muonic and hadronic tensor components**: 
```yaml
    input_grids          : [
                            [ GridGlobal, PfCand_electron, PfCand_gamma, Electron ], # e-gamma
                            [ GridGlobal, PfCand_muon, Muon ], # muons
                            [ GridGlobal, PfCand_chHad, PfCand_nHad ] # hadrons
                           ]
```

scaling parameters are added by hands, scaling for _tau_pt_, _tau_eta_ and _tau_inside_ecal_crack_ variables copied from already existing scaling file, for _rho_ linear scaling applied approximately on interval 0-50, the rho distribution:
![image](https://user-images.githubusercontent.com/31743376/135773714-4d875051-5468-4c8c-b223-344a3874ecaf.png)

P.S: should any additional high-level tau variables be added to the global-varaibles tensors? 