### PR TITLE
Evaluation pipeline [part 1]

### DIFF
--- a/Evaluation/apply_training.py
+++ b/Evaluation/apply_training.py
@@ -42,7 +42,7 @@ def main(cfg: DictConfig) -> None:
        
     # time_checkpoints = [time.time()]
     input_file_name = to_absolute_path(cfg.path_to_file)
-    output_file_name = cfg.file_alias
+    output_file_name = cfg.file_alias + '_pred'
     with uproot.open(input_file_name) as f:
         t = f['taus']
         n_taus = len(t['evt'].array())
@@ -68,7 +68,7 @@ def main(cfg: DictConfig) -> None:
 
     # store into intermediate hdf5 file
     predictions = pd.DataFrame({f'node_{tau_type}': predictions[:, int(idx)] for idx, tau_type in tau_types_names.items()})
-    targets = pd.DataFrame({f'target_{tau_type}': targets[:, int(idx)] for idx, tau_type in tau_types_names.items()}, dtype=np.int64)
+    targets = pd.DataFrame({f'node_{tau_type}': targets[:, int(idx)] for idx, tau_type in tau_types_names.items()}, dtype=np.int64)
     predictions.to_hdf(f'{output_file_name}.h5', key='predictions', mode='w', format='fixed', complevel=1, complib='zlib')
     targets.to_hdf(f'{output_file_name}.h5', key='targets', mode='r+', format='fixed', complevel=1, complib='zlib')
     

--- a/Evaluation/apply_training.py
+++ b/Evaluation/apply_training.py
@@ -1,0 +1,81 @@
+import os
+import sys
+import json
+from tqdm import tqdm
+
+import uproot
+import numpy as np
+import pandas as pd
+from tensorflow.keras.models import load_model
+
+import mlflow
+import hydra
+from hydra.utils import to_absolute_path
+from omegaconf import DictConfig, OmegaConf
+
+sys.path.insert(0, "../Training/python")
+import DataLoader
+
+@hydra.main(config_path='.', config_name='apply_training')
+def main(cfg: DictConfig) -> None:
+    # set up paths
+    mlflow.set_tracking_uri(f"file://{to_absolute_path(cfg.path_to_mlflow)}")
+    with mlflow.start_run(run_id=cfg.run_id) as active_run:
+        path_to_artifacts = to_absolute_path(f'{cfg.path_to_mlflow}/{active_run.info.experiment_id}/{cfg.run_id}/artifacts/')
+
+    # load the model
+    with open(to_absolute_path(f'{path_to_artifacts}/input_cfg/metric_names.json')) as f:
+        metric_names = json.load(f)
+    path_to_model = f'{path_to_artifacts}/model'
+    model = load_model(path_to_model, {name: lambda _: None for name in metric_names.keys()})
+
+    # instantiate DataLoader and get generator
+    training_cfg   = OmegaConf.to_object(cfg.training_cfg) # convert to a classical dictionary
+    scaling_cfg  = f'{path_to_artifacts}/input_cfg/{cfg.scaling_cfg}'
+    dataloader = DataLoader.DataLoader(training_cfg, scaling_cfg)
+    gen_predict = dataloader.get_predict_generator()
+    tau_types_names = training_cfg['Setup']['tau_types_names']
+
+    # time_checkpoints = [time.time()]
+    for input_file in tqdm(cfg.files_to_predict):
+        assert len(input_file)==1
+        input_file_key = list(input_file.keys())[0]
+        input_file_name = to_absolute_path(input_file_key)
+        input_file_cfg = input_file[input_file_key]
+        output_file_name = f"{input_file_cfg['vs_type']}_{input_file_cfg['alias']}"
+        with uproot.open(input_file_name) as f:
+            t = f['taus']
+            n_taus = len(t['evt'].array())
+        
+        predictions = []
+        targets = []
+        print(f'\n\n--> Processing file {input_file_name}, number of taus: {n_taus}')
+        for X,y in tqdm(gen_predict(input_file_name), total=n_taus/training_cfg['Setup']['n_tau']):
+            predictions.append(model.predict(X))
+            targets.append(y)
+            # time_checkpoints.append(time.time())
+            # print(i, " ", time_checkpoints[-1]-time_checkpoints[-2], "s.")
+        
+        # concat and check for validity
+        predictions = np.concatenate(predictions, axis=0)
+        targets = np.concatenate(targets, axis=0)
+
+        if np.any(np.isnan(predictions)):
+            raise RuntimeError("NaN in predictions. Total count = {} out of {}".format(
+                                np.count_nonzero(np.isnan(predictions)), predictions.shape))
+        if np.any(predictions < 0) or np.any(predictions > 1):
+            raise RuntimeError("Predictions outside [0, 1] range.")
+
+        # store into intermediate hdf5 file
+        predictions = pd.DataFrame({f'node_{tau_type}': predictions[:, int(idx)] for idx, tau_type in tau_types_names.items()})
+        targets = pd.DataFrame({f'target_{tau_type}': targets[:, int(idx)] for idx, tau_type in tau_types_names.items()}, dtype=np.int64)
+        predictions.to_hdf(f'{output_file_name}.h5', key='predictions', mode='w', format='fixed', complevel=1, complib='zlib')
+        targets.to_hdf(f'{output_file_name}.h5', key='targets', mode='r+', format='fixed', complevel=1, complib='zlib')
+        
+        # log to mlflow and delete intermediate file
+        with mlflow.start_run(run_id=cfg.run_id) as active_run:
+            mlflow.log_artifact(f'{output_file_name}.h5', 'predictions')
+        os.remove(f'{output_file_name}.h5')
+
+if __name__ == '__main__':
+    main()  

--- a/Evaluation/apply_training.py
+++ b/Evaluation/apply_training.py
@@ -29,9 +29,14 @@ def main(cfg: DictConfig) -> None:
     path_to_model = f'{path_to_artifacts}/model'
     model = load_model(path_to_model, {name: lambda _: None for name in metric_names.keys()})
 
+    # load baseline training cfg and update it with parsed arguments
+    training_cfg = OmegaConf.load(to_absolute_path(cfg.path_to_training_cfg))
+    if cfg.training_cfg_upd is not None:
+        training_cfg = OmegaConf.merge(training_cfg, cfg.training_cfg_upd)
+    training_cfg = OmegaConf.to_object(training_cfg)
+
     # instantiate DataLoader and get generator
-    training_cfg   = OmegaConf.to_object(cfg.training_cfg) # convert to a classical dictionary
-    scaling_cfg  = f'{path_to_artifacts}/input_cfg/{cfg.scaling_cfg}'
+    scaling_cfg  = to_absolute_path(cfg.scaling_cfg)
     dataloader = DataLoader.DataLoader(training_cfg, scaling_cfg)
     gen_predict = dataloader.get_predict_generator()
     tau_types_names = training_cfg['Setup']['tau_types_names']

--- a/Evaluation/apply_training.py
+++ b/Evaluation/apply_training.py
@@ -20,8 +20,7 @@ import DataLoader
 def main(cfg: DictConfig) -> None:
     # set up paths
     mlflow.set_tracking_uri(f"file://{to_absolute_path(cfg.path_to_mlflow)}")
-    with mlflow.start_run(run_id=cfg.run_id) as active_run:
-        path_to_artifacts = to_absolute_path(f'{cfg.path_to_mlflow}/{active_run.info.experiment_id}/{cfg.run_id}/artifacts/')
+    path_to_artifacts = to_absolute_path(f'{cfg.path_to_mlflow}/{cfg.experiment_id}/{cfg.run_id}/artifacts/')
 
     # load the model
     with open(to_absolute_path(f'{path_to_artifacts}/input_cfg/metric_names.json')) as f:
@@ -40,47 +39,43 @@ def main(cfg: DictConfig) -> None:
     dataloader = DataLoader.DataLoader(training_cfg, scaling_cfg)
     gen_predict = dataloader.get_predict_generator()
     tau_types_names = training_cfg['Setup']['tau_types_names']
-
+       
     # time_checkpoints = [time.time()]
-    for input_file in tqdm(cfg.files_to_predict):
-        assert len(input_file)==1
-        input_file_key = list(input_file.keys())[0]
-        input_file_name = to_absolute_path(input_file_key)
-        input_file_cfg = input_file[input_file_key]
-        output_file_name = f"{input_file_cfg['vs_type']}_{input_file_cfg['alias']}"
-        with uproot.open(input_file_name) as f:
-            t = f['taus']
-            n_taus = len(t['evt'].array())
-        
-        predictions = []
-        targets = []
-        print(f'\n\n--> Processing file {input_file_name}, number of taus: {n_taus}')
-        for X,y in tqdm(gen_predict(input_file_name), total=n_taus/training_cfg['Setup']['n_tau']):
-            predictions.append(model.predict(X))
-            targets.append(y)
-            # time_checkpoints.append(time.time())
-            # print(i, " ", time_checkpoints[-1]-time_checkpoints[-2], "s.")
-        
-        # concat and check for validity
-        predictions = np.concatenate(predictions, axis=0)
-        targets = np.concatenate(targets, axis=0)
+    input_file_name = to_absolute_path(cfg.path_to_file)
+    output_file_name = cfg.file_alias
+    with uproot.open(input_file_name) as f:
+        t = f['taus']
+        n_taus = len(t['evt'].array())
+    
+    predictions = []
+    targets = []
+    print(f'\n\n--> Processing file {input_file_name}, number of taus: {n_taus}')
+    for X,y in tqdm(gen_predict(input_file_name), total=n_taus/training_cfg['Setup']['n_tau']):
+        predictions.append(model.predict(X))
+        targets.append(y)
+        # time_checkpoints.append(time.time())
+        # print(i, " ", time_checkpoints[-1]-time_checkpoints[-2], "s.")
+    
+    # concat and check for validity
+    predictions = np.concatenate(predictions, axis=0)
+    targets = np.concatenate(targets, axis=0)
 
-        if np.any(np.isnan(predictions)):
-            raise RuntimeError("NaN in predictions. Total count = {} out of {}".format(
-                                np.count_nonzero(np.isnan(predictions)), predictions.shape))
-        if np.any(predictions < 0) or np.any(predictions > 1):
-            raise RuntimeError("Predictions outside [0, 1] range.")
+    if np.any(np.isnan(predictions)):
+        raise RuntimeError("NaN in predictions. Total count = {} out of {}".format(
+                            np.count_nonzero(np.isnan(predictions)), predictions.shape))
+    if np.any(predictions < 0) or np.any(predictions > 1):
+        raise RuntimeError("Predictions outside [0, 1] range.")
 
-        # store into intermediate hdf5 file
-        predictions = pd.DataFrame({f'node_{tau_type}': predictions[:, int(idx)] for idx, tau_type in tau_types_names.items()})
-        targets = pd.DataFrame({f'target_{tau_type}': targets[:, int(idx)] for idx, tau_type in tau_types_names.items()}, dtype=np.int64)
-        predictions.to_hdf(f'{output_file_name}.h5', key='predictions', mode='w', format='fixed', complevel=1, complib='zlib')
-        targets.to_hdf(f'{output_file_name}.h5', key='targets', mode='r+', format='fixed', complevel=1, complib='zlib')
-        
-        # log to mlflow and delete intermediate file
-        with mlflow.start_run(run_id=cfg.run_id) as active_run:
-            mlflow.log_artifact(f'{output_file_name}.h5', 'predictions')
-        os.remove(f'{output_file_name}.h5')
+    # store into intermediate hdf5 file
+    predictions = pd.DataFrame({f'node_{tau_type}': predictions[:, int(idx)] for idx, tau_type in tau_types_names.items()})
+    targets = pd.DataFrame({f'target_{tau_type}': targets[:, int(idx)] for idx, tau_type in tau_types_names.items()}, dtype=np.int64)
+    predictions.to_hdf(f'{output_file_name}.h5', key='predictions', mode='w', format='fixed', complevel=1, complib='zlib')
+    targets.to_hdf(f'{output_file_name}.h5', key='targets', mode='r+', format='fixed', complevel=1, complib='zlib')
+    
+    # log to mlflow and delete intermediate file
+    with mlflow.start_run(experiment_id=cfg.experiment_id, run_id=cfg.run_id) as active_run:
+        mlflow.log_artifact(f'{output_file_name}.h5', 'predictions')
+    os.remove(f'{output_file_name}.h5')
 
 if __name__ == '__main__':
     main()  

--- a/Evaluation/apply_training.py
+++ b/Evaluation/apply_training.py
@@ -15,12 +15,14 @@ from omegaconf import DictConfig, OmegaConf
 
 sys.path.insert(0, "../Training/python")
 import DataLoader
+from common import setup_gpu
 
 @hydra.main(config_path='.', config_name='apply_training')
 def main(cfg: DictConfig) -> None:
     # set up paths
     mlflow.set_tracking_uri(f"file://{to_absolute_path(cfg.path_to_mlflow)}")
     path_to_artifacts = to_absolute_path(f'{cfg.path_to_mlflow}/{cfg.experiment_id}/{cfg.run_id}/artifacts/')
+    setup_gpu(cfg.gpu_cfg)
 
     # load the model
     with open(to_absolute_path(f'{path_to_artifacts}/input_cfg/metric_names.json')) as f:

--- a/Evaluation/apply_training.yaml
+++ b/Evaluation/apply_training.yaml
@@ -24,8 +24,10 @@ path_to_file: ???
 file_alias: ??? # will be used in downstream modules for referencing this dataset
 
 # gpu setup
-gpu_cfg:
+gpu_cfg: # for running on CPU specify "gpu_cfg: null" 
   gpu_mem  : 7 # in Gb
   gpu_index: 0
 
+# misc.
 verbose: True
+checkout_train_repo: True # whether to checkout git commit used for running the training (fetched from artifacts)

--- a/Evaluation/apply_training.yaml
+++ b/Evaluation/apply_training.yaml
@@ -22,3 +22,8 @@ scaling_cfg: ${path_to_mlflow}/${experiment_id}/${run_id}/artifacts/input_cfg/Sh
 # input file for prediction
 path_to_file: ??? 
 file_alias: ??? # will be used in downstream modules for referencing this dataset
+
+# gpu setup
+gpu_cfg:
+  gpu_mem  : 7 # in Gb
+  gpu_index: 0

--- a/Evaluation/apply_training.yaml
+++ b/Evaluation/apply_training.yaml
@@ -27,3 +27,5 @@ file_alias: ??? # will be used in downstream modules for referencing this datase
 gpu_cfg:
   gpu_mem  : 7 # in Gb
   gpu_index: 0
+
+verbose: True

--- a/Evaluation/apply_training.yaml
+++ b/Evaluation/apply_training.yaml
@@ -1,10 +1,5 @@
-defaults:
-  - ../Training/configs@_global_.training_cfg: training_v1
-  - _self_
-
-# # override training cfg params for those for evaluation
-# `training_cfg` then will be passed to DataLoader class init
-training_cfg:
+# will update baseline training cfg (retrieved from run artifacts) with these parameters
+training_cfg_upd:
   Setup:
     n_tau: 1
     include_mismatched: True
@@ -19,8 +14,9 @@ training_cfg:
 path_to_mlflow: ../Training/python/2018v1/mlruns
 run_id: ???
 
-# for DataLoader class init, will be retrieved from run's artifacts
-scaling_cfg: ShuffleMergeSpectral_trainingSamples-2_files_0_50.json 
+# training/scaling cfg to init DataLoader class
+path_to_training_cfg: ${path_to_mlflow}/${experiment_id}/${run_id}/artifacts/input_cfg/training_cfg.yaml
+scaling_cfg: ${path_to_mlflow}/${experiment_id}/${run_id}/artifacts/input_cfg/ShuffleMergeSpectral_trainingSamples-2_files_0_50.json
 
 # input files section
 files_to_predict:

--- a/Evaluation/apply_training.yaml
+++ b/Evaluation/apply_training.yaml
@@ -11,15 +11,14 @@ training_cfg_upd:
     n_load_workers: 1
 
 # mlflow info
-path_to_mlflow: ../Training/python/2018v1/mlruns
+path_to_mlflow: ???
+experiment_id: ???
 run_id: ???
 
 # training/scaling cfg to init DataLoader class
 path_to_training_cfg: ${path_to_mlflow}/${experiment_id}/${run_id}/artifacts/input_cfg/training_cfg.yaml
 scaling_cfg: ${path_to_mlflow}/${experiment_id}/${run_id}/artifacts/input_cfg/ShuffleMergeSpectral_trainingSamples-2_files_0_50.json
 
-# input files section
-files_to_predict:
- - eval_data/ShuffleMergeSpectral_0.root: # relative path
-     vs_type: jet
-     alias: SM # will be used in downstream modules for referencing this dataset
+# input file for prediction
+path_to_file: ??? 
+file_alias: ??? # will be used in downstream modules for referencing this dataset

--- a/Evaluation/apply_training.yaml
+++ b/Evaluation/apply_training.yaml
@@ -1,0 +1,29 @@
+defaults:
+  - ../Training/configs@_global_.training_cfg: training_v1
+  - _self_
+
+# # override training cfg params for those for evaluation
+# `training_cfg` then will be passed to DataLoader class init
+training_cfg:
+  Setup:
+    n_tau: 1
+    include_mismatched: True
+  SetupNN:
+    n_batches: -1
+    n_batches_val: -1
+    validation_split: 0.
+    max_queue_size: 1
+    n_load_workers: 1
+
+# mlflow info
+path_to_mlflow: ../Training/python/2018v1/mlruns
+run_id: ???
+
+# for DataLoader class init, will be retrieved from run's artifacts
+scaling_cfg: ShuffleMergeSpectral_trainingSamples-2_files_0_50.json 
+
+# input files section
+files_to_predict:
+ - eval_data/ShuffleMergeSpectral_0.root: # relative path
+     vs_type: jet
+     alias: SM # will be used in downstream modules for referencing this dataset

--- a/Training/configs/training_v1.yaml
+++ b/Training/configs/training_v1.yaml
@@ -11,6 +11,7 @@ Setup:
     # tau_types_names.keys are written in accordance with tauType in the tau tuple
     tau_types_names      : { "0":"e", "1":"mu", "2":"tau", "3":"jet" }
     recompute_tautype    : True
+    include_mismatched   : False # whether to keep tau candidates with tau_type not present in `tau_types_names`
     input_dir            : "/eos/cms/store/group/phys_tau/TauML/prod_2018_v2/ShuffleMergeSpectral_trainingSamples-2/"
     input_spectrum       : "/eos/cms/store/group/phys_tau/TauML/prod_2018_v2/ShuffleMergeSpectral_TrainingSpectrum/ShuffleMergeSpectral_trainingSamples-2_spectrum.root"
     target_spectrum      : "/eos/cms/store/group/phys_tau/TauML/prod_2018_v2/ShuffleMergeSpectral_TrainingSpectrum/ShuffleMergeSpectral_trainingSamples-2_spectrum.root"

--- a/Training/interface/DataLoader_main.h
+++ b/Training/interface/DataLoader_main.h
@@ -254,6 +254,14 @@ public:
               FillCellGrid(tau, tau_i, outerCellGridRef, false);
               ++tau_i;
             }
+            else {
+              if (include_mismatched)
+                ++tau_i;
+            }
+          }
+          else {
+            if (include_mismatched)
+              ++tau_i;
           }
           ++current_entry;
         }

--- a/Training/interface/DataLoader_main.h
+++ b/Training/interface/DataLoader_main.h
@@ -239,6 +239,7 @@ public:
 
           const auto gen_match = analysis::GetGenLeptonMatch(tau);
           const auto sample_type = static_cast<analysis::SampleType>(tau.sampleType);
+          bool tau_is_set = false;
 
           if (gen_match){
             if (recompute_tautype){
@@ -253,16 +254,11 @@ public:
               FillCellGrid(tau, tau_i, innerCellGridRef, true);
               FillCellGrid(tau, tau_i, outerCellGridRef, false);
               ++tau_i;
-            }
-            else {
-              if (include_mismatched)
-                ++tau_i;
+              tau_is_set = true;
             }
           }
-          else {
-            if (include_mismatched)
-              ++tau_i;
-          }
+          if (!tau_is_set && include_mismatched)
+            ++tau_i;
           ++current_entry;
         }
         fullData = true;

--- a/Training/python/2018v1/Training_v0p1.py
+++ b/Training/python/2018v1/Training_v0p1.py
@@ -20,6 +20,7 @@ from tensorflow.keras.callbacks import Callback, ModelCheckpoint, CSVLogger
 from datetime import datetime
 
 import mlflow
+from mlflow.tracking.context.git_context import _get_git_commit
 mlflow.tensorflow.autolog(log_models=False)
 
 import hydra
@@ -340,7 +341,9 @@ def main(cfg: DictConfig) -> None:
         mlflow.log_artifacts('.hydra', 'input_cfg/hydra')
         mlflow.log_artifact('Training_v0p1.log', 'input_cfg/hydra')
 
+        # log misc. info
         mlflow.log_param('run_id', run_id)
+        mlflow.log_param('git_commit', _get_git_commit(to_absolute_path('.')))
         print(f'\nTraining has finished! Corresponding MLflow experiment name (ID): {cfg.experiment_name}({run_kwargs["experiment_id"]}), and run ID: {run_id}\n')
 
 if __name__ == '__main__':

--- a/Training/python/log_to_mlflow.py
+++ b/Training/python/log_to_mlflow.py
@@ -12,6 +12,7 @@ def main(cfg: DictConfig) -> None:
         run_kwargs = {'experiment_id': experiment.experiment_id} 
     else: # create new experiment
         experiment_id = mlflow.create_experiment(cfg.experiment_name)
+        print(f'\nCreated experiment {cfg.experiment_name} with ID: {experiment_id}')
         run_kwargs = {'experiment_id': experiment_id} 
     if cfg.run_id is not None:
         run_kwargs['run_id'] = cfg.run_id # to log data into existing run
@@ -24,7 +25,7 @@ def main(cfg: DictConfig) -> None:
                 mlflow.log_artifact(to_absolute_path(path_to_file), dir_to_log_to)
         if cfg.params_to_log is not None:
             mlflow.log_params(cfg.params_to_log)
-        print(f'\nLogged to run ID: {run.info.run_id}\n')
+        print(f'Logged to run ID: {run.info.run_id}\n')
 
 if __name__ == '__main__':
     main()

--- a/Training/python/log_to_mlflow.yaml
+++ b/Training/python/log_to_mlflow.yaml
@@ -1,5 +1,5 @@
 path_to_mlflow: 2018v1/mlruns
-experiment_name: null # if null, will create a new experiment
+experiment_name: ??? # will create a new experiment if one with specified name doesn't exist
 run_id: null # if null, will create a new run
 files_to_log: # path_to_file: target_folder_in_mlflow_run
   # ???: null

--- a/Training/python/set_mlflow_paths.py
+++ b/Training/python/set_mlflow_paths.py
@@ -17,7 +17,14 @@ def main(path_to_mlflow, exp_id, new_path_to_mlflow, new_exp_id, new_exp_name):
         new_path_to_exp = os.path.abspath(new_path_to_mlflow) + '/' + new_exp_id
     else:
         new_path_to_exp = os.path.abspath(new_path_to_mlflow) + '/' + exp_id
-
+    renamed_path_to_exp = os.path.abspath(path_to_mlflow) + '/' + new_exp_id
+    if os.path.exists(renamed_path_to_exp):
+        print(f'\nFound an existing experiment with ID={new_exp_id} in {path_to_mlflow}. \
+If runs in this experiment have the same origin, please merge them into the currently processed experiment folder, remove original folder and rerun this script. \
+Otherwise, rename experiment {new_exp_id} to a new ID to avoid overlap: \
+\n\n    python {os.path.basename(__file__)} -p {path_to_mlflow} -id {new_exp_id} -np {path_to_mlflow} -nid NEW_EXP_ID_HERE\n') 
+        return
+    
     meta_files = glob(f'{path_to_exp}/**/meta.yaml', recursive=True)
     run_folders = glob(f'{path_to_exp}/*/')
     main_meta_file = meta_files.pop(meta_files.index(f'{path_to_exp}/meta.yaml'))
@@ -61,7 +68,6 @@ def main(path_to_mlflow, exp_id, new_path_to_mlflow, new_exp_id, new_exp_name):
 
     # rename local experiment folder to new id
     if new_exp_id is not None:
-        renamed_path_to_exp = os.path.abspath(path_to_mlflow) + '/' + new_exp_id
         os.rename(path_to_exp, renamed_path_to_exp)
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR introduces the first step of the evaluation pipeline, namely `apply_training.py` script to run inference. Conceptually, it works as follows: model is fetched based on the given mlflow runID , applied to a given input file and then file with predictions is stored to artifacts of the given runID. The scripts's input arguments are specified in corresponding `apply_training.yaml` cfg file and they are:

* `training_cfg_upd`: a dictionary those parameters are then merged into/override the default training configuration taken from `path_to_training_cfg`. At this PR several parameters are reset in order to configure `DataLoader` to be used for inference. The key once are `n_tau=1` (DataLoader will yield 1 tau/batch), `include_mismatched=True` (see below), `validation_split=0.` (fraction of input dataset to set aside for validation). 
* `path_to_mlflow`: path to `mlruns` folder where the `experiment_id` will be searched
* `experiment_id`: ID of the mlflow experiment to which the given `run_id` belongs to
* `run_id`: mlflow runID which contains the info for a training of interest
* `path_to_training_cfg`: path to a training `*.yaml` configuration file. Default value is set to be the one logged to artifacts
* `scaling_cfg`: path to a `*.json` file with scaling parameters. Default value is set to be the one currently used in the training
* `path_to_file`: path to input file for which predictions are to be produced
* `file_alias`: unique string to identify this file. Used as a part of prediction file name, it will be needed downstream to refer to these predictions. 

An example of running would be:
```sh
python apply_training.py path_to_mlflow=../Training/python/2018v1/mlruns experiment_id=0 run_id=f790a2ad286c4d72ac549c8d902108a1 path_to_file=eval_data/TTToHadronic.root file_alias=TTToHadronic
```

Next, c27a5ed adds a switch `include_mismatched` to include gen mismatched entries. This is needed since now `DataLoader` [drops](https://github.com/cms-tau-pog/TauMLTools/blob/45babb742f1a15f96950e84d60c95acc9b65f7e9/Training/interface/DataLoader_main.h#L243) such events from yielding, and therefore number of entries in the input file is not equal to the number of predicted entries. This breaks the downstream evaluation code which assumes these numbers to be equal, therefore for the purpose of inference this flag is reset to `True` (default=False for training).

Lastly, git commit hash is now also logged to mlflow during the training (see 0ebbb76). This is needed mostly to keep track of the `DataLoader` source code which was used in the given training. Since `apply_training.py` by default imports the `DataLoader` class which is present at the runtime repo state, it might cause conflicts with the `DataLoader` class actually used during the training. 

At the moment, this step isn't automated, so if the current git repo state diverged from repo state used in the training, **user need to manually checkout that commit** and run `apply_training.py` from there. 