### PR TITLE
Added helping commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,18 @@ Therefore, the following workflow is suggested:
    mlflow ui -p 5000 # 5000 is the default port
    # forward this port to a machine with graphics
    ```
+### Additional helping commands 
+
+In order to check the learning process stability and convergence, tensorboard monitoring is utilized in the training script. In order to compare all existing runs in the `mlruns` folder, the following command can be used:
+
+```sh
+./Training/script/run_tensorboard.sh <PATH_TO_MLRUNS_FOLDER>
+```
+
+In order to check the final training/validation loss function and corresponding model info:
+```sh
+./Training/script/print_results.sh <PATH_TO_MLRUNS_FOLDER>
+```
 
 ## Testing NN performance
 

--- a/Training/scripts/print_results.sh
+++ b/Training/scripts/print_results.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+PATH_TO_MLFLOW=$1
+
+if ! [ -d "$PATH_TO_MLFLOW" ]; then
+    echo "ERROR: directory with mlflow output '$PATH_TO_MLFLOW' not found."
+    exit 1
+fi
+
+if ! [[ $PATH_TO_MLFLOW == *"mlruns/" || $PATH_TO_MLFLOW == *"mlruns" ]]; then
+  echo "ERROR: '$PATH_TO_MLFLOW' is not mlruns output directory."
+  exit 1
+fi
+
+DIRS=`readlink -f ${PATH_TO_MLFLOW}/*/*/meta.yaml`
+
+for PATH_GLOB in ${DIRS[@]}; do
+    RUN_ID_PATH=`echo $PATH_GLOB | sed 's|\(.*\)/.*|\1|'`
+    RUN_ID=`echo $RUN_ID_PATH |  sed 's|.*/||'`
+    NAME=`cat ${RUN_ID_PATH}/artifacts/model_summary.txt | grep 'Model:'`
+    TP=`cat ${RUN_ID_PATH}/artifacts/model_summary.txt | grep 'Trainable params:'`
+    LOSE=`cat ${RUN_ID_PATH}/metrics/weighted_tau_crossentropy_v2 | awk '{ print $2 }'`
+    LOSE_VAL=`cat ${RUN_ID_PATH}/metrics/val_weighted_tau_crossentropy_v2 | awk '{ print $2 }'`
+    echo RunID: $RUN_ID $NAME $TP loss: $LOSE val_loss: $LOSE_VAL
+done

--- a/Training/scripts/run_tensorboard.sh
+++ b/Training/scripts/run_tensorboard.sh
@@ -1,0 +1,28 @@
+# !/bin/bash
+
+PATH_TO_MLFLOW=$1
+
+if ! [ -d "$PATH_TO_MLFLOW" ]; then
+    echo "ERROR: directory with mlflow output '$PATH_TO_MLFLOW' not found."
+    exit 1
+fi
+
+if ! [[ $PATH_TO_MLFLOW == *"mlruns/" || $PATH_TO_MLFLOW == *"mlruns" ]]; then
+  echo "ERROR: '$PATH_TO_MLFLOW' is not mlruns output directory."
+  exit 1
+fi
+
+DIRS=`readlink -f ${PATH_TO_MLFLOW}/*/*/artifacts`
+
+CMD=""
+for PATH_GLOB in ${DIRS[@]}; do
+    NAME=`cat ${PATH_GLOB}/model_summary.txt | awk '$1=="Model:"{print $2}'`
+    echo $NAME " - added"
+    CMD+="${NAME}_train:${PATH_GLOB}/tensorboard_logs/train,"
+    CMD+="${NAME}_val:${PATH_GLOB}/tensorboard_logs/val,"
+done
+
+CMD=`echo $CMD | head -c -2`
+CMD="tensorboard --port=9090 --logdir_spec $CMD"
+echo "$CMD"
+eval $CMD


### PR DESCRIPTION
### Additional helping commands 

In order to check the learning process stability and convergence, tensorboard monitoring is utilized in the training script. In order to compare all existing runs in the `mlruns` folder, the following command can be used:

```sh
./Training/script/run_tensorboard.sh <PATH_TO_MLRUNS_FOLDER>
```

In order to check the final training/validation loss function and corresponding model info:
```sh
./Training/script/print_results.sh <PATH_TO_MLRUNS_FOLDER>
```