### PR TITLE
Some updates and small fixes to the Shuffle&Merge scripts

### DIFF
--- a/Analysis/bin/ShuffleMergeSpectral.cxx
+++ b/Analysis/bin/ShuffleMergeSpectral.cxx
@@ -20,7 +20,7 @@
 
 namespace analysis {
 
-void sumBasedSplit(const std::vector<size_t>& files_entries, const size_t job_idx, const size_t n_job,
+void sumBasedSplit(const std::vector<size_t>& files_entries, const size_t job_idx, const size_t n_job, const bool overflowjob,
                   std::pair<size_t, size_t>& point_entry,  std::pair<size_t, size_t>& point_exit, size_t& step)
 { 
   // sumBasedSplit splits files into n_job sub-intervals
@@ -42,6 +42,10 @@ void sumBasedSplit(const std::vector<size_t>& files_entries, const size_t job_id
    // .second - index of last event
   point_entry = find_idx(job_idx, false);
   point_exit = find_idx(job_idx, true);
+  if(overflowjob && job_idx+1 == n_job){
+    step = step + (std::accumulate(files_entries.begin(), files_entries.end(), 0) % n_job);
+    point_exit = std::make_pair(files_entries.size()-1, files_entries[files_entries.size()-1]-1);
+  }
 };
 
 enum class MergeMode { MergeAll = 1 };
@@ -84,6 +88,8 @@ struct Arguments {
     run::Argument<bool> refill_spectrum{"refill-spectrum", "If true - spectrums of the input data will be recalculated on flight, "
                                         "only events that correspond to the current job will be considered.", false};
     run::Argument<bool> enable_emptybin{"enable-emptybin", "In case of empty pt-eta bin, the probability in this bin will be set to 0", false};
+    run::Argument<bool> overflow_job{"overflow-job", "If true - include all remaining Taus from the ntuples in the last job. "
+                                        "(The number of Taus included, instead of being ignored, should be less than the number of jobs.)", false};
 };
 
 struct SourceDesc {
@@ -204,7 +210,7 @@ struct EntryDesc {
               const std::string& input_paths,
               const std::string& prefix,
               const size_t job_idx, const size_t n_jobs,
-              const bool refill_spectrum)
+              const bool refill_spectrum, const bool overflow_job)
     {
         using boost::regex;
         using boost::regex_match;
@@ -282,7 +288,7 @@ struct EntryDesc {
         if(job_idx >= n_jobs)
           throw exception("Wrong job_idx! The index should be > 0 and < n_jobs");
         
-        sumBasedSplit(files_entries, job_idx, n_jobs,point_entry, point_exit, total_entries);
+        sumBasedSplit(files_entries, job_idx, n_jobs, overflow_job, point_entry, point_exit, total_entries);
         
         std::cout <<  name << ": " <<
                      "Entry point-> " << point_entry.first << " " << point_entry.second << ", " <<
@@ -363,12 +369,12 @@ public:
             if(ttype_entries.at(type)->GetBinContent(i_x,i_y)==0) {
               if(enable_emptybin) {
                 std::cout << "WARNING: empty bin (pt_i:"
-                          << i_x << ", eta_i:" << i_y  << ") "
+                          << i_y << ", eta_i:" << i_x  << ") "
                           << ToString(type) << " " << groupname << std::endl;
                 ratio_h->SetBinContent(i_x,i_y,0.0);
               } else {
                 throw exception("Empty bin (pt_i:'%1%', eta_i:'%2%') for tau type '%3%' in '%4%'.")
-                % i_x % i_y % ToString(type) % groupname;
+                % i_y % i_x % ToString(type) % groupname;
               }
             } else {
             ratio_h->SetBinContent(i_x,i_y,
@@ -398,6 +404,7 @@ public:
           double dis_scale = std::min(1.0, exp_disbalance*
                              ttype_entries.at(type)->Integral(0,binNx,binNy-1,binNy)*
                              ttype_prob.at(type)->GetBinContent(x,y));
+          if(dis_scale<=0.0) dis_scale = 1.0;
           if(dis_scale!=1.0)
             std::cout << "WARNING: Disbalance for "<< ToString(type)
                       <<" is bigger, scale factor will be applied" << std::endl;
@@ -548,6 +555,7 @@ public:
       }
       std::cout << "No taus at: " << current_datagroup << std::endl;
       std::cout << "stop procedure..." << std::endl;
+      PrintStatusReport();
       return false;
     }
 
@@ -559,7 +567,7 @@ public:
       for(auto source: sources) {
         size_t n_processed = source.second->GetNumberOfProcessed();
         size_t n_total = source.second->GetTotalEntries();
-        std::cout << source.first << ":" << (float)n_processed/n_total*100 <<"% ";
+        std::cout << source.first << ":" << (float)n_processed/n_total*100 <<"% (" << n_total-n_processed << " left),";
       }
       std::cout << std::endl;
     }
@@ -825,7 +833,7 @@ private:
         for(const auto& item : reader.GetItems()){
             entries.emplace_back(item.second,  args.path_spectrum(), args.input(),
                                  args.prefix(), args.job_idx(), args.n_jobs(),
-                                 args.refill_spectrum());
+                                 args.refill_spectrum(), args.overflow_job());
         }
         return entries;
     }

--- a/Analysis/bin/ShuffleMergeSpectral.cxx
+++ b/Analysis/bin/ShuffleMergeSpectral.cxx
@@ -404,7 +404,9 @@ public:
           double dis_scale = std::min(1.0, exp_disbalance*
                              ttype_entries.at(type)->Integral(0,binNx,binNy-1,binNy)*
                              ttype_prob.at(type)->GetBinContent(x,y));
-          if(dis_scale<=0.0) dis_scale = 1.0;
+          if(dis_scale<=0.0) // As a result of ttype_entries.at(type)->Integral(0,binNx,binNy-1,binNy)==0.0
+            throw exception("Disbalance scale factor is 0 for histogram '%1%' in '%2%' for bin (pt_i:'%3%', eta_i:'%4%')")
+            % ToString(type) % groupname % binNy % binNx;
           if(dis_scale!=1.0)
             std::cout << "WARNING: Disbalance for "<< ToString(type)
                       <<" is bigger, scale factor will be applied" << std::endl;

--- a/Analysis/law/ShuffleMergeSpectral/tasks.py
+++ b/Analysis/law/ShuffleMergeSpectral/tasks.py
@@ -33,9 +33,11 @@ class ShuffleMergeSpectral(Task, HTCondorWorkflow, law.LocalWorkflow):
   max_entries       = luigi.Parameter(default = '', description = 'maximal number of entries in output train+test tuples')
   n_threads         = luigi.Parameter(default = '', description = 'number of threads')
   lastbin_disbalance= luigi.Parameter(default = '', description = 'maximal acceptable disbalance between low pt and high pt region')
+  lastbin_takeall   = luigi.Parameter(default = '', description = 'to take all events from the last bin up to acceptable disbalance')
   seed              = luigi.Parameter(default = '', description = 'random seed to initialize the generator used for sampling')
   enable_emptybin   = luigi.Parameter(default = '', description = 'enable empty pt-eta bins in the spectrum')
   refill_spectrum   = luigi.Parameter(default = '', description = 'to recalculated spectrums of the input data on flight')
+  overflow_job      = luigi.Parameter(default = '', description = 'to consider remaining taus in last job')
 
   def create_branch_map(self):
     self.output_dir = '/'.join([self.output_path, 'tmp'])
@@ -83,12 +85,14 @@ class ShuffleMergeSpectral(Task, HTCondorWorkflow, law.LocalWorkflow):
       ['--n-threads'        , str(self.n_threads)               ] * (not self.n_threads          is '') +\
       ['--disabled-branches', quote(str(self.disabled_branches))] * (not self.disabled_branches  is '') +\
       ['--lastbin-disbalance',str(self.lastbin_disbalance)      ] * (not self.lastbin_disbalance is '') +\
+      ['--lastbin-takeall'  , str(self.lastbin_takeall)         ] * (not self.lastbin_takeall    is '') +\
       ['--compression-algo' , str(self.compression_algo)        ] * (not self.compression_algo   is '') +\
       ['--compression-level', str(self.compression_level)       ] * (not self.compression_level  is '') +\
       ['--parity'           , str(self.parity)                  ] * (not self.parity             is '') +\
       ['--max-entries'      , str(self.max_entries)             ] * (not self.max_entries        is '') +\
       ['--enable-emptybin'  , str(self.enable_emptybin)         ] * (not self.enable_emptybin    is '') +\
-      ['--refill-spectrum' , str(self.refill_spectrum)         ] * (not self.refill_spectrum    is '')  )
+      ['--refill-spectrum'  , str(self.refill_spectrum)         ] * (not self.refill_spectrum    is '') +\
+      ['--overflow-job'     , str(self.overflow_job)            ] * (not self.overflow_job       is '')  )
 
     print ('>> {}'.format(command))
     proc = subprocess.Popen(command, shell = True, stdout = subprocess.PIPE, stderr = subprocess.PIPE)

--- a/Production/scripts/validation_tool.py
+++ b/Production/scripts/validation_tool.py
@@ -34,7 +34,7 @@ ROOT.gROOT.SetBatch(not args.visual)
 ROOT.gStyle.SetOptStat(0)
 
 for formats in args.formats.split(","):
-  pdf_dir = '/'.join([args.output, formats])
+  pdf_dir = os.path.join(args.output, formats)
   if not os.path.exists(pdf_dir):
     os.makedirs(pdf_dir)
 
@@ -47,7 +47,7 @@ PVAL_THRESHOLD = args.pvthreshold
 ## binning of tested variables (dataset group id and dataset id are guessed from jsons)
 BINS = {
   'tau_pt'    : (100, 0, 1000),
-  'tau_eta'   : (10, -2.4, 2.4),
+  'tau_eta'   : (10, -2.5, 2.5),
   'tauType' : (4, 0, 4),
   'sampleType': (5, 0, 5),
 }

--- a/Production/scripts/validation_tool.py
+++ b/Production/scripts/validation_tool.py
@@ -24,6 +24,7 @@ parser.add_argument('--n_threads'     , default  = 1   , type = int, help = 'ena
 parser.add_argument('--id_json'       , required = True, type = str, help = 'dataset id json file')
 parser.add_argument('--group_id_json' , required = True, type = str, help = 'dataset group id json file')
 parser.add_argument('--use_dataset_id', action = 'store_true', help = 'Add \'dataset_id\' column for comparison and binning')
+parser.add_argument('--formats'       , default ='pdf', type = str, help = 'comma separated list of output file formats')
 
 parser.add_argument('--visual', action = 'store_true', help = 'Won\'t run the script in batch mode')
 parser.add_argument('--legend', action = 'store_true', help = 'Draw a TLegend on canvases')
@@ -32,9 +33,10 @@ args = parser.parse_args()
 ROOT.gROOT.SetBatch(not args.visual)
 ROOT.gStyle.SetOptStat(0)
 
-pdf_dir = '/'.join([args.output, 'pdf'])
-if not os.path.exists(pdf_dir):
-  os.makedirs(pdf_dir)
+for formats in args.formats.split(","):
+  pdf_dir = '/'.join([args.output, formats])
+  if not os.path.exists(pdf_dir):
+    os.makedirs(pdf_dir)
 
 JSON_DICT      = OrderedDict()
 OUTPUT_ROOT    = ROOT.TFile.Open('{}/histograms.root'.format(args.output), 'RECREATE')
@@ -44,10 +46,10 @@ PVAL_THRESHOLD = args.pvthreshold
 
 ## binning of tested variables (dataset group id and dataset id are guessed from jsons)
 BINS = {
-  'tau_pt'    : (50, 0, 5000),
-  'tau_eta'   : (5, -3.2, 3.2),
-  'tauType' : (10, 0, 10),
-  'sampleType': (20, -1, 19),
+  'tau_pt'    : (100, 0, 1000),
+  'tau_eta'   : (10, -2.4, 2.4),
+  'tauType' : (4, 0, 4),
+  'sampleType': (5, 0, 5),
 }
 
 class Lazy_container:
@@ -110,7 +112,8 @@ class Entry:  ## 2D entry (chunk_id x variable)
     if args.legend:
       leg.Draw("SAME")
     
-    can.SaveAs('{}/pdf/{}.pdf'.format(args.output, self.tdir.replace('/', '_')), 'pdf')
+    for formats in args.formats.split(","):
+      can.SaveAs('{}/{}/{}.{}'.format(args.output, formats, self.tdir.replace('/', '_'), formats), formats)
     can.Write()
 
     OUTPUT_ROOT.cd()
@@ -150,8 +153,8 @@ if (*it == %s) return line;
 
   id_json       = json.load(open(args.id_json, 'r'))
   group_id_json = json.load(open(args.group_id_json, 'r'))
-  ids = id_json.values()
-  group_ids = group_id_json.values()
+  ids = [id_json[key] for key in sorted(id_json.keys())]
+  group_ids = [group_id_json[key] for key in sorted(group_id_json.keys())]
 
   BINS['uh_dataset_group_id'] = (len(group_ids), 0, len(group_ids))
   BINS['uh_dataset_id']       = (len(ids), 0, len(ids))
@@ -171,6 +174,12 @@ if (*it == %s) return line;
 
   ## binned distributions
   BINNED_VARIABLES = ['tauType', 'sampleType', 'uh_dataset_group_id'] + ['uh_dataset_id']*args.use_dataset_id
+  BINNED_VARIABLENAMES = {
+    'tauType': {0:'e', 1:'mu', 2:'tau', 3:'jet', 4:'emb_e', 5:'emb_mu', 6:'emb_tau', 7:'emb_jet', 8:'data'},
+    'sampleType': {1:'MC', 2:'Embedded', 3:'Data'},
+    'uh_dataset_group_id': {ii:jj for ii,jj in enumerate(sorted(group_id_json.keys()))},
+    'uh_dataset_id': {ii:jj for ii,jj in enumerate(sorted(id_json.keys()))}
+  }
   ptrs_tau_pt = {
     binned_variable: Lazy_container(dataframe.Histo3D(model('tau_pt', third = binned_variable), 'chunk_id', 'tau_pt', binned_variable))
       for binned_variable in BINNED_VARIABLES
@@ -199,19 +208,19 @@ if (*it == %s) return line;
   entry_di  = Entry(var = 'uh_dataset_id'      , histo = ptr_di .hst)
 
   entries_tau_pt = [
-    Entry(var = 'tau_pt', histo = to_2D(ptrs_tau_pt[binned_variable].hst, jj+1), tdir = '/'.join([binned_variable, str(bb), 'tau_pt']))
+    Entry(var = 'tau_pt', histo = to_2D(ptrs_tau_pt[binned_variable].hst, jj+1), tdir = '/'.join([binned_variable, str(bb) if bb not in BINNED_VARIABLENAMES[binned_variable] else BINNED_VARIABLENAMES[binned_variable][bb], 'tau_pt']))
       for binned_variable in BINNED_VARIABLES
       for jj, bb in enumerate(range(*BINS[binned_variable][1:]))
   ] ; entries_tau_pt = [ee for ee in entries_tau_pt if ee.hst.GetEntries()]
 
   entries_tau_eta = [
-    Entry(var = 'tau_eta', histo = to_2D(ptrs_tau_eta[binned_variable].hst, jj+1), tdir = '/'.join([binned_variable, str(bb), 'tau_eta']))
+    Entry(var = 'tau_eta', histo = to_2D(ptrs_tau_eta[binned_variable].hst, jj+1), tdir = '/'.join([binned_variable, str(bb) if bb not in BINNED_VARIABLENAMES[binned_variable] else BINNED_VARIABLENAMES[binned_variable][bb], 'tau_eta']))
       for binned_variable in BINNED_VARIABLES
       for jj, bb in enumerate(range(*BINS[binned_variable][1:]))
   ] ; entries_tau_eta = [ee for ee in entries_tau_eta if ee.hst.GetEntries()]
   
   entries_dataset_id = [
-    Entry(var = 'uh_dataset_id', histo = to_2D(ptrs_dataset_id[binned_variable].hst, jj+1), tdir = '/'.join([binned_variable, str(bb), 'uh_dataset_id']))
+    Entry(var = 'uh_dataset_id', histo = to_2D(ptrs_dataset_id[binned_variable].hst, jj+1), tdir = '/'.join([binned_variable, str(bb) if bb not in BINNED_VARIABLENAMES[binned_variable] else BINNED_VARIABLENAMES[binned_variable][bb], 'uh_dataset_id']))
       for binned_variable in ['uh_dataset_group_id']
       for jj, bb in enumerate(range(*BINS[binned_variable][1:]))
       if args.use_dataset_id
@@ -225,6 +234,8 @@ if (*it == %s) return line;
   for ee in entries:
     ee.run_test(test = args.test)
     ee.save_data()
+  print ("ID names for uh_dataset_group_id:", sorted(BINNED_VARIABLENAMES['uh_dataset_group_id'].items()))
+  if args.use_dataset_id: print ("ID names for uh_dataset_id:", sorted(BINNED_VARIABLENAMES['uh_dataset_id'].items()))
 
   OUTPUT_ROOT.Close()
   json.dump(JSON_DICT, OUTPUT_JSON, indent = 4)


### PR DESCRIPTION
In ShuffleMergeSpectral:
- Added option to include all remaining Taus in the last job, which are otherwise neglected because the total number of Taus didn't evenly divide between all jobs
- Minor verbose fix
- Fix for lastbin_takeall: Scale=1 if bin is empty
- Added verbose to show the number of remaining Taus to be filled, as well as the status after one sample group has finished (showing the number of Taus that are neglected)

In the law tasks.py:
- Added new implemented option from above, and lastbin-takeall which was missing previously

In validation_tool:
- Added option to save output in other filetypes (default is unchanged, just pdf)
- Titles of output include the name of the sample type, Tau type or group name (instead of just indices)
- Also prints the groups belong to the numbered indices for the "uh_dataset_group_id" plot
