### PR TITLE
Update feature scaling code to not scale disabled features

### DIFF
--- a/Training/python/feature_scaling.py
+++ b/Training/python/feature_scaling.py
@@ -28,6 +28,7 @@ if __name__ == '__main__':
     # read cfg parameters
     setup_dict = scaling_dict['Scaling_setup']
     features_dict = scaling_dict['Features_all']
+    disabledFeatures = [variableName for sublist in (scaling_dict['Features_disable'][featureType] for featureType in scaling_dict['Features_disable']) for variableName in sublist] # get the list of disabled features, and flatten it.
     #
     assert type(args.var_types) == list
     if args.var_types[0] == "-1" and len(args.var_types) == 1:
@@ -95,8 +96,10 @@ if __name__ == '__main__':
                 for var_type in var_types:
                     # loop over variables of the given type
                     for var_dict in features_dict[var_type]:
-                        begin_var = time.time()
                         (var, (selection_cut, aliases, scaling_type, *lim_params)), = var_dict.items()
+                        if var in disabledFeatures:
+                            continue #we don't need to consider disabled features in the scaling
+                        begin_var = time.time()
                         if scaling_type == 'linear':
                             # dict with scaling params already fully filled after init_dictionaries() call, here compute only variable's quantiles
                             if len(lim_params) == 2 and lim_params[0] <= lim_params[1]:


### PR DESCRIPTION
I ran into some issues with the feature scaling code attempting to create scalings for things that were in the `Features_disable` portion of `training_v1.yaml`, which crashed because these features were disabled because they were empty.

I have added a quick check to disable feature scaling for things that are already disabled in the training config, which works for my purposes, to prevent it scaling empty features. I figured I would check whether this would be useful in the main branch.