### PR TITLE
UL2018 changes and re-definition of GenLepton interface for genParticlePlusGeant collection

### DIFF
--- a/Analysis/interface/GenLepton.h
+++ b/Analysis/interface/GenLepton.h
@@ -98,67 +98,70 @@ public:
         return leptons;
     }
 
-    template<typename IntVector, typename LongVector, typename FloatVector>
-    static GenLepton fromRootTuple(int lastMotherIndex,
-                                   const IntVector& genParticle_pdgId,
-                                   const LongVector& genParticle_mother,
-                                   const IntVector& genParticle_charge,
-                                   const IntVector& genParticle_isFirstCopy,
-                                   const IntVector& genParticle_isLastCopy,
-                                   const FloatVector& genParticle_pt,
-                                   const FloatVector& genParticle_eta,
-                                   const FloatVector& genParticle_phi,
-                                   const FloatVector& genParticle_mass,
-                                   const FloatVector& genParticle_vtx_x,
-                                   const FloatVector& genParticle_vtx_y,
-                                   const FloatVector& genParticle_vtx_z)
+    template <template <typename> class CollectionType>
+    static GenLepton fromRootTuple(
+                                   const bool isGeantPlusSim_,
+                                   int lastMotherIndex,
+                                   const CollectionType<Int_t>& genParticle_pdgId,
+                                   const CollectionType<Long64_t>& genParticle_mother,
+                                   const CollectionType<Int_t>& genParticle_charge,
+                                   const CollectionType<Int_t>& genParticle_isFirstCopy,
+                                   const CollectionType<Int_t>& genParticle_isLastCopy,
+                                   const CollectionType<Float_t>& genParticle_pt,
+                                   const CollectionType<Float_t>& genParticle_eta,
+                                   const CollectionType<Float_t>& genParticle_phi,
+                                   const CollectionType<Float_t>& genParticle_mass,
+                                   const CollectionType<Float_t>& genParticle_vtx_x,
+                                   const CollectionType<Float_t>& genParticle_vtx_y,
+                                   const CollectionType<Float_t>& genParticle_vtx_z)
     {
         try {
 
-            const size_t N = genParticle_pdgId.size();
-            assert(N <= MaxNumberOfParticles);
-            assert(genParticle_mother.size() == N);
-            assert(genParticle_charge.size() == N);
-            assert(genParticle_isFirstCopy.size() == N);
-            assert(genParticle_isLastCopy.size() == N);
-            assert(genParticle_pt.size() == N);
-            assert(genParticle_eta.size() == N);
-            assert(genParticle_phi.size() == N);
-            assert(genParticle_mass.size() == N);
-            assert(genParticle_vtx_x.size() == N);
-            assert(genParticle_vtx_y.size() == N);
-            assert(genParticle_vtx_z.size() == N);
-            assert(lastMotherIndex >= -1);
+        const size_t N = genParticle_pdgId.size();
+        assert(N <= MaxNumberOfParticles);
+        assert(genParticle_mother.size() == N);
+        assert(genParticle_charge.size() == N);
+        assert(genParticle_isFirstCopy.size() == N);
+        assert(genParticle_isLastCopy.size() == N);
+        assert(genParticle_pt.size() == N);
+        assert(genParticle_eta.size() == N);
+        assert(genParticle_phi.size() == N);
+        assert(genParticle_mass.size() == N);
+        assert(genParticle_vtx_x.size() == N);
+        assert(genParticle_vtx_y.size() == N);
+        assert(genParticle_vtx_z.size() == N);
+        assert(lastMotherIndex >= -1);
 
-            GenLepton lepton;
-            lepton.particles_->resize(N);
-            lepton.firstCopy_ = &lepton.particles_->at(lastMotherIndex + 1);
-            for(size_t n = 0; n < N; ++n) {
-                GenParticle& p = lepton.particles_->at(n);
-                p.pdgId = genParticle_pdgId.at(n);
-                p.charge = genParticle_charge.at(n);
-                p.isFirstCopy = genParticle_isFirstCopy.at(n);
-                p.isLastCopy = genParticle_isLastCopy.at(n);
-                p.p4 = LorentzVectorM(genParticle_pt.at(n), genParticle_eta.at(n),
-                                      genParticle_phi.at(n), genParticle_mass.at(n));
-                p.vertex = Point3D(genParticle_vtx_x.at(n), genParticle_vtx_y.at(n), genParticle_vtx_z.at(n));
-                std::set<size_t> mothers;
-                Long64_t mother_encoded = genParticle_mother.at(n);
-                if(mother_encoded >= 0) {
-                    do {
-                        Long64_t mother_index = mother_encoded % static_cast<Long64_t>(MaxNumberOfParticles);
-                        mother_encoded = (mother_encoded - mother_index) / static_cast<int>(MaxNumberOfParticles);
-                        mothers.insert(static_cast<size_t>(mother_index));
-                    } while(mother_encoded > 0);
-                }
-                for(size_t mother_index : mothers) {
-                    assert(mother_index < N);
-                    p.mothers.insert(&lepton.particles_->at(mother_index));
-                    lepton.particles_->at(mother_index).daughters.insert(&p);
-                }
+        GenLepton lepton;
+        if(isGeantPlusSim_) lepton.enableGenPlusSimParticleMode();
+        lepton.particles_->resize(N);
+        lepton.firstCopy_ = &lepton.particles_->at(lastMotherIndex + 1);
+        for(size_t n = 0; n < N; ++n) {
+            GenParticle& p = lepton.particles_->at(n);
+            p.pdgId = genParticle_pdgId.at(n);
+            p.charge = genParticle_charge.at(n);
+            p.isFirstCopy = genParticle_isFirstCopy.at(n);
+            p.isLastCopy = genParticle_isLastCopy.at(n);
+            p.p4 = LorentzVectorM(genParticle_pt.at(n), genParticle_eta.at(n),
+                                  genParticle_phi.at(n), genParticle_mass.at(n));
+            p.vertex = Point3D(genParticle_vtx_x.at(n), genParticle_vtx_y.at(n), genParticle_vtx_z.at(n));
+            std::set<size_t> mothers;
+            Long64_t mother_encoded = genParticle_mother.at(n);
+            if(mother_encoded >= 0) {
+                do {
+                    Long64_t mother_index = mother_encoded % static_cast<Long64_t>(MaxNumberOfParticles);
+                    mother_encoded = (mother_encoded - mother_index) / static_cast<int>(MaxNumberOfParticles);
+                    mothers.insert(static_cast<size_t>(mother_index));
+                } while(mother_encoded > 0);
             }
-            lepton.initialize();
-            return lepton;
+            for(size_t mother_index : mothers) {
+                assert(mother_index < N);
+                p.mothers.insert(&lepton.particles_->at(mother_index));
+                lepton.particles_->at(mother_index).daughters.insert(&p);
+            }
+        }
+        lepton.initialize();
+        return lepton;
         } catch(std::exception& e) {
             std::cerr << "ERROR: " << e.what() << std::endl;
             throw;
@@ -477,11 +480,25 @@ private:
         if(nFinalStateElectrons_ == 1 && nFinalStateMuons_ == 0 && 
            nNeutralHadrons_ == 0 && nChargedHadrons_ == 0)
             return Kind::TauDecayedToElectron;
+        // Hard fix of bug:
+        // pdgId=-15 status=8
+        // +-> pdgId=11 status=8
+        // +-> pdgId=-11 status=8
+        if(nFinalStateElectrons_ == 2 && nFinalStateMuons_ == 0 && 
+           nNeutralHadrons_ == 0 && nChargedHadrons_ == 0)
+            return Kind::TauDecayedToElectron;
         if(nFinalStateElectrons_ == 0 && nFinalStateMuons_ == 1 && 
            nNeutralHadrons_ == 0 && nChargedHadrons_ == 0)
             return Kind::TauDecayedToMuon;
+        // Hard fix of bug:
+        // pdgId=-15 status=8
+        // +-> pdgId=11 status=8
+        // +-> pdgId=-13 status=8
+        if(nFinalStateElectrons_ == 1 && nFinalStateMuons_ == 1 && 
+           nNeutralHadrons_ == 0 && nChargedHadrons_ == 0)
+            return Kind::TauDecayedToMuon;
         if(pdg == GenParticle::PdgId::tau && lastCopy_->daughters.empty())
-            return Kind::TauDecayedToHadrons;
+            return Kind::Other;
         ThrowError("unable to determine gen lepton kind in GeantMode");
     }
 

--- a/Analysis/interface/GenLepton.h
+++ b/Analysis/interface/GenLepton.h
@@ -482,9 +482,10 @@ private:
             return Kind::TauDecayedToElectron;
         // Hard fix of bug:
         // pdgId=-15 status=8
-        // +-> pdgId=11 status=8
+        // +-> pdgId=11 status=8 <- pt<0.001
+        // +-> pdgId=11 status=8 <- pt<0.001
         // +-> pdgId=-11 status=8
-        if(nFinalStateElectrons_ == 2 && nFinalStateMuons_ == 0 && 
+        if(nFinalStateElectrons_ >= 2 && nFinalStateMuons_ == 0 && 
            nNeutralHadrons_ == 0 && nChargedHadrons_ == 0)
             return Kind::TauDecayedToElectron;
         if(nFinalStateElectrons_ == 0 && nFinalStateMuons_ == 1 && 
@@ -492,9 +493,10 @@ private:
             return Kind::TauDecayedToMuon;
         // Hard fix of bug:
         // pdgId=-15 status=8
-        // +-> pdgId=11 status=8
+        // +-> pdgId=11 status=8 <- pt<0.001
+        // +-> pdgId=11 status=8 <- pt<0.001
         // +-> pdgId=-13 status=8
-        if(nFinalStateElectrons_ == 1 && nFinalStateMuons_ == 1 && 
+        if(nFinalStateElectrons_ >= 1 && nFinalStateMuons_ == 1 &&
            nNeutralHadrons_ == 0 && nChargedHadrons_ == 0)
             return Kind::TauDecayedToMuon;
         if(pdg == GenParticle::PdgId::tau && lastCopy_->daughters.empty())

--- a/Analysis/interface/TauTuple.h
+++ b/Analysis/interface/TauTuple.h
@@ -76,6 +76,7 @@
     VAR(Int_t, genLepton_lastMotherIndex) /* index of the last mother in genParticle_* vectors:
                                              >= 0 if at least one mother is available, -1 otherwise */ \
     VAR(std::vector<Int_t>, genParticle_pdgId) /* PDG ID */ \
+    VAR(std::vector<Int_t>, genParticle_status) /* status of the genParticle */ \
     VAR(std::vector<Long64_t>, genParticle_mother) /* index of the mother. If the paricle has more than one mother,
                                                       genParticle_mother = sum(10^(3*(mother_number-1)) * mother_index).
                                                       The maximal number of mothers = 6. */ \

--- a/Production/interface/TauJet.h
+++ b/Production/interface/TauJet.h
@@ -109,7 +109,7 @@ public:
                   const pat::ElectronCollection& electrons, const pat::MuonCollection& muons,
                   const pat::IsolatedTrackCollection& isoTracks, const pat::PackedCandidateCollection& lostTracks,
                   const reco::GenParticleCollection* genParticles, const reco::GenJetCollection* genJets,
-                  bool requireGenMatch, bool requireGenORRecoTauMatch, bool applyRecoPtSieve);
+                  bool requireGenMatch, bool requireGenORRecoTauMatch, bool applyRecoPtSieve, bool genPlusSimParticleMode);
 
     TauJetBuilder(const TauJetBuilder&) = delete;
     TauJetBuilder& operator=(const TauJetBuilder&) = delete;

--- a/Production/plugins/TauTupleProducer.cc
+++ b/Production/plugins/TauTupleProducer.cc
@@ -381,6 +381,7 @@ private:
                 tauTuple().genParticle_vtx_x.push_back(p.vertex.x());
                 tauTuple().genParticle_vtx_y.push_back(p.vertex.y());
                 tauTuple().genParticle_vtx_z.push_back(p.vertex.z());
+                tauTuple().genParticle_status.push_back(p.status);
             }
         }
     }

--- a/Production/plugins/TauTupleProducer.cc
+++ b/Production/plugins/TauTupleProducer.cc
@@ -127,6 +127,7 @@ public:
         requireGenMatch(cfg.getParameter<bool>("requireGenMatch")),
         requireGenORRecoTauMatch(cfg.getParameter<bool>("requireGenORRecoTauMatch")),
         applyRecoPtSieve(cfg.getParameter<bool>("applyRecoPtSieve")),
+        genPlusSimParticleMode(cfg.getParameter<bool>("genPlusSimParticleMode")),
         genEvent_token(mayConsume<GenEventInfoProduct>(cfg.getParameter<edm::InputTag>("genEvent"))),
         genParticles_token(mayConsume<reco::GenParticleCollection>(cfg.getParameter<edm::InputTag>("genParticles"))),
         genJets_token(mayConsume<reco::GenJetCollection>(cfg.getParameter<edm::InputTag>("genJets"))),
@@ -269,7 +270,7 @@ private:
 
         TauJetBuilder builder(builderSetup, *taus, *boostedTaus, *jets, *fatJets, *cands, *electrons, *muons,
                               *isoTracks, *lostTracks, genParticles, genJets, requireGenMatch,
-                              requireGenORRecoTauMatch, applyRecoPtSieve);
+                              requireGenORRecoTauMatch, applyRecoPtSieve, genPlusSimParticleMode);
         const auto& tauJets = builder.GetTauJets();
         tauTuple().total_entries = static_cast<int>(tauJets.size());
         for(size_t tauJetIndex = 0; tauJetIndex < tauJets.size(); ++tauJetIndex) {
@@ -285,7 +286,7 @@ private:
             FillJet(tauJet.fatJet, "fatJet_");
 
             FillPFCandidates(tauJet.cands, "pfCand_");
-            FillPFCandidates(tauJet.cands, "lostTrack_");
+            FillPFCandidates(tauJet.lostTracks, "lostTrack_");
             FillElectrons(tauJet.electrons);
             FillMuons(tauJet.muons);
             FillIsoTracks(tauJet.isoTracks);
@@ -897,7 +898,7 @@ private:
     }
 
 private:
-    const bool isMC, isEmbedded, requireGenMatch, requireGenORRecoTauMatch, applyRecoPtSieve;
+    const bool isMC, isEmbedded, requireGenMatch, requireGenORRecoTauMatch, applyRecoPtSieve, genPlusSimParticleMode;
     TauJetBuilderSetup builderSetup;
 
     edm::EDGetTokenT<GenEventInfoProduct> genEvent_token;

--- a/Production/python/Production.py
+++ b/Production/python/Production.py
@@ -202,7 +202,9 @@ process.tauTupleProducer = cms.EDAnalyzer('TauTupleProducer',
 
     lheEventProduct    = cms.InputTag('externalLHEProducer'),
     genEvent           = cms.InputTag('generator'),
-    genParticles       = cms.InputTag('prunedGenParticles'),
+    genParticles       = cms.InputTag('genParticlePlusGeant'),
+    genPlusSimParticleMode   = cms.bool(True),
+    # genParticles       = cms.InputTag('prunedGenParticles'),
     puInfo             = cms.InputTag('slimmedAddPileupInfo'),
     vertices           = vtx_InputTag,
     rho                = cms.InputTag('fixedGridRhoAll'),
@@ -242,6 +244,8 @@ else:
 
 if isPhase2:
     process.p.insert(0, process.slimmedElectronsMerged)
+elif isUltraLegacy:
+    pass
 else:
     process.p.insert(2, process.boostedSequence)
 

--- a/Production/python/sampleConfig.py
+++ b/Production/python/sampleConfig.py
@@ -5,8 +5,8 @@ from sets import Set
 import FWCore.ParameterSet.Config as cms
 import os
 
-mcSampleTypes = Set([ 'MC_16', 'MC_17', 'MC_18', 'Emb_16', 'Emb_17', 'Emb_18ABC', 'Emb_18D', 'MC_Phase2_111X', 'MC_Phase2_110X'])
-dataSampleTypes = Set([ 'Run2016' , 'Run2017', 'Run2018ABC', 'Run2018D' ])
+mcSampleTypes = Set([ 'MC_16', 'MC_17', 'MC_18', 'MC_UL18','Emb_16', 'Emb_17', 'Emb_18ABC', 'Emb_18D', 'MC_Phase2_111X', 'MC_Phase2_110X'])
+dataSampleTypes = Set([ 'Run2016' , 'Run2017', 'Run2018ABC', 'Run2018D', 'RunUL2018' ])
 
 periodDict = { 'MC_16' : 'Run2016',
                'Run2016' : 'Run2016',
@@ -15,8 +15,10 @@ periodDict = { 'MC_16' : 'Run2016',
                'Run2017' : 'Run2017',
                'Emb_17' : 'Run2017',
                'MC_18' : 'Run2018',
+               'MC_UL18' : 'Run2018',
                'Run2018ABC' : 'Run2018',
                'Run2018D' : 'Run2018',
+               'RunUL2018' : 'Run2018',
                'Emb_18ABC' : 'Run2018',
                'Emb_18D' : 'Run2018',
                'MC_Phase2_110X' : 'Phase2',
@@ -31,8 +33,10 @@ globalTagMap = { 'MC_16' : '102X_mcRun2_asymptotic_v7',
                  'Run2017' : '102X_dataRun2_v12',
                  'Emb_17' : '102X_dataRun2_v12',
                  'MC_18' : '102X_upgrade2018_realistic_v20',
+                 'MC_UL18' : '106X_upgrade2018_realistic_v16_L1v1',
                  'Run2018ABC' : '102X_dataRun2_v12',
                  'Run2018D' : '102X_dataRun2_Prompt_v15',
+                 'RunUL2018' : '106X_dataRun2_v35',
                  'Emb_18ABC' : '102X_dataRun2_v12',
                  'Emb_18D' : '102X_dataRun2_Prompt_v15',
                  'MC_Phase2_110X' : '110X_mcRun4_realistic_v3',
@@ -81,3 +85,13 @@ def GetPeriodCfg(sampleType):
         return Phase2C9
     else:
         raise RuntimeError('Period = "{}" is not supported.'.format(period))
+
+def isUL(sampleType):
+    if sampleType not in periodDict:
+        print "ERROR: unknown sample type = '{}'".format(sampleType)
+        sys.exit(1)
+    if sampleType == 'MC_UL18' or sampleType == 'RunUL2018':
+        return True
+    else:
+        return False
+

--- a/Production/src/TauJet.cc
+++ b/Production/src/TauJet.cc
@@ -93,14 +93,14 @@ TauJetBuilder::TauJetBuilder(const TauJetBuilderSetup& setup, const pat::TauColl
               const pat::ElectronCollection& electrons, const pat::MuonCollection& muons,
               const pat::IsolatedTrackCollection& isoTracks, const pat::PackedCandidateCollection& lostTracks,
               const reco::GenParticleCollection* genParticles, const reco::GenJetCollection* genJets,
-              bool requireGenMatch, bool requireGenORRecoTauMatch, bool applyRecoPtSieve) :
+              bool requireGenMatch, bool requireGenORRecoTauMatch, bool applyRecoPtSieve, bool genPlusSimParticleMode) :
     setup_(setup), taus_(taus), boostedTaus_(boostedTaus), jets_(jets), fatJets_(fatJets), cands_(cands),
     electrons_(electrons), muons_(muons), isoTracks_(isoTracks), lostTracks_(lostTracks), genParticles_(genParticles),
     genJets_(genJets), requireGenMatch_(requireGenMatch), requireGenORRecoTauMatch_(requireGenORRecoTauMatch),
     applyRecoPtSieve_(applyRecoPtSieve)
 {
     if(genParticles)
-        genLeptons_ = reco_tau::gen_truth::GenLepton::fromGenParticleCollection(*genParticles);
+        genLeptons_ = reco_tau::gen_truth::GenLepton::fromGenParticleCollection(*genParticles, genPlusSimParticleMode);
     Build();
 }
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Tools to perform machine learning studies for tau lepton reconstruction and iden
    ```
    where supported `ENV_NAME` are:
    - `prod2018`: for production of root-tuples for 2018 pre-UL datasets and pre-processing steps up to Shuffle&Merge
+   - `prod2018UL`: for production of root-tuples for 2018 UL datasets and pre-processing steps up to Shuffle&Merge
    - `phase2`: for production of root-tuples for Phase 2 datasets and pre-processing steps up to Shuffle&Merge
    - `lcg`: using LCG environment, if it is available (e.g. lxplus)
    - `conda`: using tau-ml conda environment -- this is the recommended environment to perform an actual NN training

--- a/env.sh
+++ b/env.sh
@@ -3,7 +3,7 @@
 if [ $# -ne 1 ] ; then
     echo "Setup environment for TauMLTools"
     echo "Usage: source setup.sh mode"
-    echo "Supported modes: prod2018 phase2 lcg conda "
+    echo "Supported modes: prod2018 prod2018UL phase2 lcg conda "
     return 1
 fi
 
@@ -19,7 +19,7 @@ function run_cmd {
     fi
 }
 
-if [ $MODE = "prod2018" -o $MODE = "phase2" ] ; then
+if [ $MODE = "prod2018" -o $MODE = "phase2" -o $MODE = "prod2018UL" ] ; then
     if [ $MODE = "prod2018" ] ; then
         CMSSW_VER=CMSSW_10_6_20
         APPLY_BOOSTED_FIX=1
@@ -28,6 +28,10 @@ if [ $MODE = "prod2018" -o $MODE = "phase2" ] ; then
         CMSSW_VER=CMSSW_11_2_5
         APPLY_BOOSTED_FIX=0
         export SCRAM_ARCH=slc7_amd64_gcc900
+    elif [ $MODE = "prod2018UL" ] ; then
+        CMSSW_VER=CMSSW_10_6_27
+        APPLY_BOOSTED_FIX=0
+        export SCRAM_ARCH=slc7_amd64_gcc700
     fi
 
     if ! [ -f soft/$CMSSW_VER/.installed ] ; then


### PR DESCRIPTION
That is preliminary PR in order to open the discussion about on GenLepton class re-implementation.

Description of the GenParticleFromSim plugin can be found here: https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideGenParticleFromSim 
Right now, the Sim Particles in genParticlePlusGeant collection contains the following problems:
1) all status=8 and statusFlag() not defined
2) no neutrinos (maybe because in Simulation they are just dropped)
3) all the showers are included (hadronic, electronic and all radiation) => definition basing on the final state does not make much sense. 

Right now, all definitions in genParticlePlusGeant for the particles with status=8 is based on the first order daughters and some additional modifications of the decay tree processing.

Unfortunately, at the moment the output looks a bit suspicious: for the 1000 events of the private MC https://cmsweb.cern.ch/das/request?view=list&limit=50&instance=prod%2Fphys03&input=%2F*%2F*myshched-MiniAOD*%2F
where I have signal qq->stau->tau+lsp,  qq->stau+jet->tau+lsp,  qq->stau+2jets->tau+lsp (so having 2 taus is guarantied per event) there are unrealistic ratios of  leptonic_taus/hadronic_taus what is potentially due to some mistakes in definition:
```
Electron Candidates: pass=0          all=2044       -- eff=0.00 % cumulative eff=0.00 %
Muon Candidates: pass=0          all=2044       -- eff=0.00 % cumulative eff=0.00 %
TauElectron Candidates: pass=48         all=2044       -- eff=2.35 % cumulative eff=2.35 %
TauMuon Candidates: pass=46         all=2044       -- eff=2.25 % cumulative eff=2.25 %
Tau Candidates: pass=1202       all=2044       -- eff=58.81 % cumulative eff=58.81 %
Other Candidates: pass=0          all=2044       -- eff=0.00 % cumulative eff=0.00 %
No GenLepton: pass=748        all=2044       -- eff=36.59 % cumulative eff=36.59 %
```
 