### PR TITLE
A few changes

### DIFF
--- a/Training/interface/DataLoader_main.h
+++ b/Training/interface/DataLoader_main.h
@@ -194,6 +194,7 @@ public:
             ("w_1_"+tau_name).c_str(),
             ("w_1_"+tau_name).c_str()
         ));
+        hist_weights[tau_type]->SaveAs(("Temp_"+tau_name+".root").c_str()); // It's required that all bins are filled in these histograms; save them to check incase binning is too fine and some bins are empty
 
         target_histogram.reset();
         input_histogram .reset();

--- a/Training/interface/DataLoader_main.h
+++ b/Training/interface/DataLoader_main.h
@@ -194,7 +194,7 @@ public:
             ("w_1_"+tau_name).c_str(),
             ("w_1_"+tau_name).c_str()
         ));
-        hist_weights[tau_type]->SaveAs(("Temp_"+tau_name+".root").c_str()); // It's required that all bins are filled in these histograms; save them to check incase binning is too fine and some bins are empty
+        if (debug) hist_weights[tau_type]->SaveAs(("Temp_"+tau_name+".root").c_str()); // It's required that all bins are filled in these histograms; save them to check incase binning is too fine and some bins are empty
 
         target_histogram.reset();
         input_histogram .reset();

--- a/Training/python/feature_scaling.py
+++ b/Training/python/feature_scaling.py
@@ -73,7 +73,7 @@ if __name__ == '__main__':
 
     # loop over input files
     for file_i, (file_name_i, file_name) in enumerate(zip(file_names_ix, file_names)): # file_i used internally to count number of processed files
-        print("Processing file:",file_i)
+        print("Processing file:",file_i,",",file_name)
         log_scaling_params = not (file_i%log_step) or (file_i == n_files-1)
         with uproot.open(file_name, array_cache='5 GB') as f:
             if len(f.keys()) == 0: # some input ROOT files can be corrupted and uproot can't recover for it. These files are skipped in computations

--- a/Training/python/plot_quantile_ranges.py
+++ b/Training/python/plot_quantile_ranges.py
@@ -116,13 +116,8 @@ def main(
                     print(f'[INFO] Failed to retrieve scaling parameters for var_name={var_name} and cone_type={cone_type}: skipping this variable')
                     continue
 
-                ### fetch clamping params
+                ### fetch mean for clamping params
                 mean = var_scaling['mean']
-                has_None = mean==None
-                if not has_None:
-                    clamp_range_left = mean + var_scaling['lim_min']*var_scaling['std']
-                    clamp_range_right = mean + var_scaling['lim_max']*var_scaling['std']
-                    clamp_range = [clamp_range_left, clamp_range_right]
 
                 ### fetch quantiles
                 median = var_quantiles['median']
@@ -147,8 +142,11 @@ def main(
 
                 ### check for anomalous behaviour
                 suspicious_dict = {}
-                has_None = has_None or (None in [median, min_value, max_value, one_sigma_left, two_sigma_left, three_sigma_left, five_sigma_left, one_sigma_right, two_sigma_right, three_sigma_right, five_sigma_right])
+                has_None = None in [mean, median, min_value, max_value, one_sigma_left, two_sigma_left, three_sigma_left, five_sigma_left, one_sigma_right, two_sigma_right, three_sigma_right, five_sigma_right]
                 if not has_None:
+                    clamp_range_left = mean + var_scaling['lim_min']*var_scaling['std']
+                    clamp_range_right = mean + var_scaling['lim_max']*var_scaling['std']
+                    clamp_range = [clamp_range_left, clamp_range_right]
                     suspicious_dict['left_within'] = clamp_range_left > two_sigma_left
                     suspicious_dict['right_within'] = clamp_range_right < two_sigma_right
                     # suspicious_dict['left_beyond'] = clamp_range_left < five_sigma_left
@@ -157,8 +155,15 @@ def main(
                     suspicious_dict['two_sigma_empty'] = two_sigma_left == two_sigma_right
                     suspicious_dict['three_sigma_empty'] = three_sigma_left == three_sigma_right
                     suspicious_dict['five_sigma_empty'] = five_sigma_left == five_sigma_right
-                is_suspicious = any(suspicious_dict.values())
-                if (is_suspicious or not only_suspicious) and not has_None:
+                    is_suspicious = any(suspicious_dict.values())
+                elif mean is None:
+                    print(f'       {var_name}, {cone_type}: mean is empty')
+                    continue
+                else:
+                    print(f'       {var_name}, {cone_type}: quantiles are empty')
+                    continue
+
+                if is_suspicious or not only_suspicious:
                     plot_ranges(file_id, var_name, cone_type, None if var_scaling_type=='linear' else mean, median, min_value, max_value,
                                 clamp_range, one_sigma_range, two_sigma_range, three_sigma_range,
                                 suspicious_dict, savepath=f'{output_folder}/{var_type}', close_plot=True)
@@ -167,8 +172,6 @@ def main(
                     for k, v in suspicious_dict.items():
                         print(f'           {k}: {v}')
                     print()
-                elif has_None:
-                    print(f'       {var_name}, {cone_type}: Is empty')
                 else:
                     print(f'       {var_name}, {cone_type}: OK')
 

--- a/Training/python/plot_quantile_ranges.py
+++ b/Training/python/plot_quantile_ranges.py
@@ -54,7 +54,7 @@ def plot_ranges(file_id, var_name, cone_type, mean, median, min_value, max_value
     plt.ylim(ylim)
     plt.xlim(xlim)
     plt.legend()
-    plt.show()
+    if not close_plot: plt.show()
     if savepath is not None:
         fig.savefig(f'{savepath}/{var_name}_{cone_type}.png')
     if close_plot:

--- a/Training/python/plot_scaling_convergence.py
+++ b/Training/python/plot_scaling_convergence.py
@@ -63,7 +63,7 @@ def plot_running_diff(running_diff_mean, running_diff_std,
     axs[1].hlines(.1, axs[1].get_xlim()[0], axs[1].get_xlim()[1]-1, ls=':', linewidth=3, label='10\% level')
     axs[1].vlines(49.5, *axs[1].get_ylim(), 'black', linewidth=1.5)
     # plt.legend(loc='upper center')
-    plt.show()
+    if not close_plot: plt.show()
     if savepath is not None:
         fig.savefig(f'{savepath}/{var_type}_{cone_type}.png')
     if close_plot:

--- a/Training/python/scaling_utils.py
+++ b/Training/python/scaling_utils.py
@@ -173,11 +173,11 @@ def compute_mean(sums, counts, aggregate=True, *file_range):
     if aggregate:
         if file_range:
             assert len(file_range) == 2 and file_range[0] <= file_range[1]
-            return sums[file_range[0]:file_range[1]].sum()/counts[file_range[0]:file_range[1]].sum()
+            return sums[file_range[0]:file_range[1]].sum()/counts[file_range[0]:file_range[1]].sum() if counts[file_range[0]:file_range[1]].sum()>1 else 0.
         else:
-            return sums.sum()/counts.sum()
+            return sums.sum()/counts.sum() if counts.sum()>1 else 0.
     else:
-        return sums/counts
+        return sums/counts if counts>1 else 0.
 
 def compute_std(sums, sums2, counts, aggregate=True, *file_range):
     """
@@ -198,11 +198,11 @@ def compute_std(sums, sums2, counts, aggregate=True, *file_range):
             assert len(file_range) == 2 and file_range[0] <= file_range[1]
             average2 = sums2[file_range[0]:file_range[1]].sum()/counts[file_range[0]:file_range[1]].sum()
             average = sums[file_range[0]:file_range[1]].sum()/counts[file_range[0]:file_range[1]].sum()
-            return np.sqrt(average2 - average**2)
+            return np.sqrt(average2 - average**2) if counts[file_range[0]:file_range[1]].sum()>1 else 1.
         else:
-            return np.sqrt(sums2.sum()/counts.sum() - (sums.sum()/counts.sum())**2)
+            return np.sqrt(sums2.sum()/counts.sum() - (sums.sum()/counts.sum())**2) if counts.sum()>1 else 1.
     else:
-        return np.sqrt(sums2/counts - (sums/counts)**2)
+        return np.sqrt(sums2/counts - (sums/counts)**2) if counts>1 else 1.
 
 def get_quantiles(var_array):
     """
@@ -216,6 +216,7 @@ def get_quantiles(var_array):
     """
     quantile_dict = {}
     var_array = ak.to_numpy(ak.flatten(var_array, axis=-1))
+    if np.size(var_array)==0: return {'median': 0., 'min': 0., 'max': 0., '1sigma': {'left': 0., 'right': 0.}, '2sigma': {'left': 0., 'right': 0.}, '3sigma': {'left': 0., 'right': 0.}, '5sigma': {'left': 0., 'right': 0.}}
     quantile_dict['median'] = np.median(var_array).astype(float)
     quantile_dict['min'] = np.min(var_array).astype(float)
     quantile_dict['max'] = np.max(var_array).astype(float)

--- a/Training/python/scaling_utils.py
+++ b/Training/python/scaling_utils.py
@@ -157,7 +157,7 @@ def init_dictionaries(features_dict, cone_selection_dict, n_files):
                 raise ValueError(f"In variable {var}: scaling_type should be one of [no_scaling, categorical, linear, normal]")
     return sums, sums2, counts, scaling_params, quantile_params
 
-def compute_mean(sums, counts, aggregate=True, *file_range):
+def compute_mean(sums, counts, aggregate=True, mincount=1, *file_range):
     """
     Assuming input arrays correspond to per file sums and counts for a given feature's values, derive means either on the file-by-file basis, or via aggregating & averaging values over all/specified range of input files.
 
@@ -170,16 +170,18 @@ def compute_mean(sums, counts, aggregate=True, *file_range):
     Returns:
         float (np.array) with mean (means per file)
     """
+    if counts.sum() <= mincount: return None
     if aggregate:
         if file_range:
             assert len(file_range) == 2 and file_range[0] <= file_range[1]
-            return sums[file_range[0]:file_range[1]].sum()/counts[file_range[0]:file_range[1]].sum() if counts[file_range[0]:file_range[1]].sum()>1 else 0.
+            if counts[file_range[0]:file_range[1]].sum() <= mincount: return None
+            return sums[file_range[0]:file_range[1]].sum()/counts[file_range[0]:file_range[1]].sum()
         else:
-            return sums.sum()/counts.sum() if counts.sum()>1 else 0.
+            return sums.sum()/counts.sum()
     else:
-        return sums/counts if counts>1 else 0.
+        return sums/counts
 
-def compute_std(sums, sums2, counts, aggregate=True, *file_range):
+def compute_std(sums, sums2, counts, aggregate=True, mincount=1, *file_range):
     """
     Assuming input arrays correspond to per file (squared) sums and counts for a given feature's values, derive standard deviation either on the file-by-file basis, or via aggregating & averaging values over all/specified range of input files.
 
@@ -193,18 +195,20 @@ def compute_std(sums, sums2, counts, aggregate=True, *file_range):
     Returns:
         float (np.array) with std (stds per file)
     """
+    if counts.sum() <= mincount: return None
     if aggregate:
         if file_range:
             assert len(file_range) == 2 and file_range[0] <= file_range[1]
+            if counts[file_range[0]:file_range[1]].sum() <= mincount: return None
             average2 = sums2[file_range[0]:file_range[1]].sum()/counts[file_range[0]:file_range[1]].sum()
             average = sums[file_range[0]:file_range[1]].sum()/counts[file_range[0]:file_range[1]].sum()
-            return np.sqrt(average2 - average**2) if counts[file_range[0]:file_range[1]].sum()>1 else 1.
+            return np.sqrt(average2 - average**2)
         else:
-            return np.sqrt(sums2.sum()/counts.sum() - (sums.sum()/counts.sum())**2) if counts.sum()>1 else 1.
+            return np.sqrt(sums2.sum()/counts.sum() - (sums.sum()/counts.sum())**2)
     else:
-        return np.sqrt(sums2/counts - (sums/counts)**2) if counts>1 else 1.
+        return np.sqrt(sums2/counts - (sums/counts)**2)
 
-def get_quantiles(var_array):
+def get_quantiles(var_array, mincount=0):
     """
     Compute for a given feature array `var_array` characteristics of its distribution: median, min/max, 1/2/3/5 sigma (under assumption of normality) intervals
 
@@ -216,7 +220,7 @@ def get_quantiles(var_array):
     """
     quantile_dict = {}
     var_array = ak.to_numpy(ak.flatten(var_array, axis=-1))
-    if np.size(var_array)==0: return {'median': 0., 'min': 0., 'max': 0., '1sigma': {'left': 0., 'right': 0.}, '2sigma': {'left': 0., 'right': 0.}, '3sigma': {'left': 0., 'right': 0.}, '5sigma': {'left': 0., 'right': 0.}}
+    if np.size(var_array) <= mincount: return {'median': None, 'min': None, 'max': None, '1sigma': {'left': None, 'right': None}, '2sigma': {'left': None, 'right': None}, '3sigma': {'left': None, 'right': None}, '5sigma': {'left': None, 'right': None}}
     quantile_dict['median'] = np.median(var_array).astype(float)
     quantile_dict['min'] = np.min(var_array).astype(float)
     quantile_dict['max'] = np.max(var_array).astype(float)
@@ -313,10 +317,19 @@ def fill_aggregators(tree, var, var_type, file_i, file_name_i, cone_type, cone_d
         if fill_scaling_params:
             mean_ = compute_mean(sums[var_type][var], counts[var_type][var], aggregate=True)
             std_ = compute_std(sums[var_type][var], sums2[var_type][var], counts[var_type][var], aggregate=True)
-            scaling_params[var_type][var]['global']['mean'] = float(format(mean_, '.4g')) # round to 4 significant digits
-            scaling_params[var_type][var]['global']['std'] = float(format(std_, '.4g'))
+            if mean_ == None:
+                print(f"Low statistics in {var} for mean computation")
+                scaling_params[var_type][var]['global']['mean'] = None
+            else:
+                scaling_params[var_type][var]['global']['mean'] = float(format(mean_, '.4g')) # round to 4 significant digits
+            if std_ == None:
+                print(f"Low statistics in {var} for std computation")
+                scaling_params[var_type][var]['global']['std'] = None
+            else:
+                scaling_params[var_type][var]['global']['std'] = float(format(std_, '.4g'))
         if quantile_params:
             quantile_params[var_type][var]['global'][file_name_i] = get_quantiles(var_array)
+            if None in quantile_params[var_type][var]['global'][file_name_i].values(): print(f"Low statistics in {var} for quantile computation")
     elif cone_type == 'inner' or cone_type == 'outer':
         tau_pt_name, tau_eta_name, tau_phi_name = cone_selection_dict['TauFlat']['var_names']['pt'], cone_selection_dict['TauFlat']['var_names']['eta'], cone_selection_dict['TauFlat']['var_names']['phi']
         tau_pt_array, tau_eta_array, tau_phi_array = tree.arrays([tau_pt_name, tau_eta_name, tau_phi_name], cut=None, aliases=None, how=tuple)
@@ -332,10 +345,19 @@ def fill_aggregators(tree, var, var_type, file_i, file_name_i, cone_type, cone_d
         if fill_scaling_params:
             mean_ = compute_mean(sums[var_type][var][cone_type], counts[var_type][var][cone_type], aggregate=True)
             std_ = compute_std(sums[var_type][var][cone_type], sums2[var_type][var][cone_type], counts[var_type][var][cone_type], aggregate=True)
-            scaling_params[var_type][var][cone_type]['mean'] = float(format(mean_, '.4g'))
-            scaling_params[var_type][var][cone_type]['std'] = float(format(std_, '.4g'))
+            if mean_ == None:
+                print(f"Low statistics in {var} for mean computation")
+                scaling_params[var_type][var][cone_type]['mean'] = None
+            else:
+                scaling_params[var_type][var][cone_type]['mean'] = float(format(mean_, '.4g'))
+            if std_ == None:
+                print(f"Low statistics in {var} for std computation")
+                scaling_params[var_type][var][cone_type]['std'] = None
+            else:
+                scaling_params[var_type][var][cone_type]['std'] = float(format(std_, '.4g'))
         if quantile_params:
             quantile_params[var_type][var][cone_type][file_name_i] = get_quantiles(var_array[cone_mask])
+            if None in quantile_params[var_type][var][cone_type][file_name_i].values(): print(f"Low statistics in {var} for quantile computation")
     else:
         raise ValueError(f'cone_type for {var_type} should be either inner, or outer')
 


### PR DESCRIPTION
- Training/interface/DataLoader_main.h: Saves histograms of Taus over the rebinned pt/eta plane. If any bin is empty, the training crashes, so it's useful for debugging, and to see where any high imbalance may be.
- Training/python/feature_scaling.py: Small verbose change
- Training/python/plot_quantile_ranges.py & Training/python/plot_scaling_convergence.py: Avoid opening plots, as the scripts are stalled as long as a plot is displayed (at least, this is what happens for me)
- Training/python/scaling_utils.py: Treatment in feature scaling if a variable has no entries (or very few, like only 1). This is how i handled missing "pfCand_gamma" track information, instead of commenting it out.