### PR TITLE
Tau visualisation tool

### DIFF
--- a/Analysis/notebooks/tau_visualisation.ipynb
+++ b/Analysis/notebooks/tau_visualisation.ipynb
@@ -1,0 +1,313 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "5797c176-1be1-412c-affe-a0fcd7f87780",
+   "metadata": {},
+   "source": [
+    "## Import libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13bca385-cbaa-4aac-867d-9dddb57b711b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import uproot\n",
+    "import awkward as ak\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "\n",
+    "import plotly.graph_objects as go\n",
+    "import plotly.express as px\n",
+    "from ipywidgets import widgets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9de55ab3-f814-43e8-a5a4-5b9679bec48f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ctype_to_name = {\n",
+    "    0: 'Undefined',\n",
+    "    1: 'Charged hadron',\n",
+    "    2: 'Electron', \n",
+    "    3: 'Muon', \n",
+    "    4: 'Gamma', \n",
+    "    5: 'Neutral hadron',\n",
+    "    6: 'HF tower, hadron',\n",
+    "    7: 'HF tower, EM',\n",
+    "            }\n",
+    "dm_to_name = {\n",
+    "    0:  '1pr',\n",
+    "    1:  '1pr+1pi0',\n",
+    "    5:  '2pr',\n",
+    "    6:  '2pr+1pi0',\n",
+    "    10: '3pr',\n",
+    "    11: '3pr+1pi0'\n",
+    "}\n",
+    "tau_type_to_name = {\n",
+    "    1: 'e',\n",
+    "    2: \"mu\",\n",
+    "    3: \"tau -> e\",\n",
+    "    4: \"tau -> mu\",\n",
+    "    5: \"tau -> h\",\n",
+    "    -2147483648: 'not_defined'\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "43ced2ed-3a8b-4485-a77d-7ff174406e38",
+   "metadata": {},
+   "source": [
+    "## Configuration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c423fbe5-cfc5-4b3d-aaf5-f7bc50b0f8d4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "N_INNER_CELLS   = 11\n",
+    "INNER_CELL_SIZE = 0.02\n",
+    "N_OUTER_CELLS   = 21\n",
+    "OUTER_CELL_SIZE = 0.05\n",
+    "\n",
+    "INNER_LOC = N_INNER_CELLS*INNER_CELL_SIZE/2\n",
+    "OUTER_LOC = N_OUTER_CELLS*OUTER_CELL_SIZE/2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cdad879b-849b-4b59-a490-444c54011c86",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "PATH_TO_FILE = 'data/DYJetsToLL_M-50-amcatnloFXFX_ext2/eventTuple_98.root'\n",
+    "TREE_NAME = 'taus'\n",
+    "EVENT_ID_0 = 33323 # ID of the event to be initially displayed"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1c850e49-e6ae-4717-998b-2b0ed39207eb",
+   "metadata": {},
+   "source": [
+    "## Data loading & preprocessing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5e7858ac-e085-4592-bcb6-d78b7f57ca5f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with uproot.open(PATH_TO_FILE) as f:\n",
+    "    t = f[TREE_NAME]\n",
+    "    a = t.arrays(['pfCand_pt', 'pfCand_eta', 'pfCand_phi', 'pfCand_particleType',\n",
+    "                  'tau_pt', 'tau_eta', 'tau_phi', 'genLepton_kind',\n",
+    "                  'tau_decayMode', 'tau_decayModeFinding',], how='zip')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5a922dbd-c418-4062-8782-3e5a6b6b84ce",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a = a[a['genLepton_kind'] > 0]\n",
+    "a = a[abs(a['tau_phi'])<2*np.pi] # remove candidates with unphysical tau_phi"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "71d0f964-d802-46ce-a907-7e0173344a32",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# compute dphi and scale it to [-pi, pi]\n",
+    "dphi_array = (a['pfCand', 'phi'] - a['tau_phi'])\n",
+    "dphi_array = np.where(dphi_array <= np.pi, dphi_array, dphi_array - 2*np.pi)\n",
+    "dphi_array = np.where(dphi_array >= -np.pi, dphi_array, dphi_array + 2*np.pi)\n",
+    "a['pfCand', 'dphi'] = dphi_array\n",
+    "\n",
+    "# compute deta\n",
+    "a['pfCand', 'deta'] = a['pfCand', 'eta'] - a['tau_eta']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "db2096b4-bc67-4319-a9d0-8f2475541c2f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def compose_tau_data(a, event_id):\n",
+    "    c_type = list(map(ctype_to_name.get, a['pfCand', 'particleType'][event_id]))\n",
+    "    tau_type = tau_type_to_name[a['genLepton_kind'][event_id]]\n",
+    "    tau_DM = dm_to_name[a['tau_decayMode'][event_id]]\n",
+    "    tau_pt = a['tau_pt'][event_id]\n",
+    "    tau_df = pd.DataFrame({'deta': a['pfCand', 'deta'][event_id],\n",
+    "                   'dphi': a['pfCand', 'dphi'][event_id],\n",
+    "                   'pt': a['pfCand', 'pt'][event_id],\n",
+    "                   'DM': a['tau_decayMode'][event_id],\n",
+    "                   'type': c_type})\n",
+    "    return tau_df, tau_pt, tau_type, tau_DM"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "18a16492-0f57-4d45-9b54-c6657c3eacaf",
+   "metadata": {},
+   "source": [
+    "## Plot single figure"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e6dc7547-f4c7-4e4f-9e9e-205dc869f03e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def create_figure(a, event_id):\n",
+    "    tau_df, tau_pt, tau_type, tau_DM = compose_tau_data(a, event_id)\n",
+    "    fig = px.scatter(tau_df, x=\"deta\", y=\"dphi\", color=\"type\",\n",
+    "                 size='pt', hover_data=['pt', 'deta', 'dphi'],\n",
+    "                 title=f'gen type: {tau_type};   pt: {tau_pt: .1f} GeV;   reco DM: {tau_DM}') # ;   event ID: {event_id}\n",
+    "    fig.add_shape(type=\"rect\",\n",
+    "        x0=-INNER_LOC, y0=-INNER_LOC, x1=INNER_LOC, y1=INNER_LOC,\n",
+    "        line=dict(color=\"RoyalBlue\"),\n",
+    "    )\n",
+    "    fig.add_shape(type=\"rect\",\n",
+    "        x0=-OUTER_LOC, y0=-OUTER_LOC, x1=OUTER_LOC, y1=OUTER_LOC,\n",
+    "        line=dict(color=\"LightCoral\"),\n",
+    "    )\n",
+    "    fig.update_layout(autosize=False,\n",
+    "        width=650,\n",
+    "        height=650,           \n",
+    "    )  \n",
+    "    fig.update_xaxes(range=[-0.8, 0.8])\n",
+    "    fig.update_yaxes(range=[-0.8, 0.8])\n",
+    "    return fig"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7b183dc7-2126-49e1-8342-89e270eee1fa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = create_figure(a, EVENT_ID_0)\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "28d421fa-2cb5-48bd-a43d-3d9374cc674a",
+   "metadata": {},
+   "source": [
+    "## Build widget"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "07086bbd-8659-48c2-bc5e-5bea126a1ebd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Assign figure to an empty widget\n",
+    "g = go.FigureWidget(data=fig,\n",
+    "                    layout=go.Layout(\n",
+    "                        title=dict(\n",
+    "                            text='Widget'\n",
+    "                        ),\n",
+    "                    ))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "77b3fbc7-751f-4827-a451-30a3b0c3d071",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "event_text = widgets.IntText(EVENT_ID_0) # switcher for event ID\n",
+    "container = widgets.HBox(children=[event_text])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8b37e403-a811-4768-b606-c8dffcb4b95b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def response(change):  \n",
+    "    event_id = event_text.value\n",
+    "    if event_id < len(a) and event_id > -1:\n",
+    "        tau_df, tau_pt, tau_type, tau_DM = compose_tau_data(a, event_id)\n",
+    "        fig = px.scatter(tau_df, x=\"deta\", y=\"dphi\", color=\"type\",\n",
+    "                         size='pt', hover_data=['pt', 'deta', 'dphi'],)\n",
+    "        with g.batch_update():\n",
+    "            g.data = ()\n",
+    "            [g.add_traces(item) for item in fig.data]\n",
+    "            g.layout.title.text = f'gen type: {tau_type};   reco pt: {tau_pt: .1f} GeV;   reco DM: {tau_DM}'\n",
+    "            \n",
+    "event_text.observe(response, names=\"value\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d5ae46b8-b342-4a9d-8f2f-6e6212465663",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "widgets.VBox([container, g])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9bd2e869-785f-42e0-8246-0feffad155e9",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "tau-ml",
+   "language": "python",
+   "name": "tau-ml"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This is a PR with a preliminary version of a tau visualisation tool. The idea behind it is to visualise the distribution of constituents within a single tau candidate in (delta eta, delta phi) plane. Visualisation is based on [`plotly`](https://plotly.com/python/) library to have it in a widget form with a flexible and interactive UI. At the moment each particle constituent is represented with a color-coded (based on a particle type) circle which size is proportional to a particle pt.

Note: it can happen that `plotly` figures aren't rendered properly out-of-the-box depending on the version of Jupyter/JupyterLab. In that case please look through these [instructions](https://plotly.com/python/getting-started/) for ways to install the lib/fix this issue.

To-do items:
- [ ] add selection based on evt/run/.../tau_index
- [ ] add generated level particles (overlaid option)
- [ ] fix color code for particle type (at the moment it changes once event ID is changed)
- [ ] add option to choose a feature to be visualised (at the moment it is constituents' pt by default)