### PR TITLE
Updated the core of the DataLoader

### DIFF
--- a/Evaluation/apply_training.py
+++ b/Evaluation/apply_training.py
@@ -70,7 +70,9 @@ def main(cfg: DictConfig) -> None:
     predictions = []
     targets = []
     if cfg.verbose: print(f'\n\n--> Processing file {input_file_name}, number of taus: {n_taus}\n')
-    for X,y in tqdm(gen_predict(input_file_name), total=n_taus/training_cfg['Setup']['n_tau']):
+    for X,y in tqdm(gen_predict(input_file_name), 
+                    total=(int(n_taus/training_cfg['Setup']['n_tau']) +\
+                          (n_taus%training_cfg['Setup']['n_tau'] > 0))):
         predictions.append(model.predict(X))
         targets.append(y)
     

--- a/Evaluation/apply_training.py
+++ b/Evaluation/apply_training.py
@@ -73,9 +73,17 @@ def main(cfg: DictConfig) -> None:
     for X,y in tqdm(gen_predict(input_file_name), 
                     total=(int(n_taus/training_cfg['Setup']['n_tau']) +\
                           (n_taus%training_cfg['Setup']['n_tau'] > 0))):
-        predictions.append(model.predict(X))
+
+        pred_all = np.zeros(y.shape)
+        valid = np.logical_not((y==0).all(axis=1))
+        pred_all[valid] = model.predict(tuple(X_part[valid] for X_part in X))
+
+        predictions.append(pred_all)
         targets.append(y)
-    
+
+        # predictions.append(model.predict(X))
+        # targets.append(y)
+
     # concat and check for validity
     predictions = np.concatenate(predictions, axis=0)
     targets = np.concatenate(targets, axis=0)

--- a/Evaluation/apply_training.yaml
+++ b/Evaluation/apply_training.yaml
@@ -1,8 +1,9 @@
 # will update baseline training cfg (retrieved from run artifacts) with these parameters
 training_cfg_upd:
   Setup:
-    n_tau: 1
-    include_mismatched: True
+    n_tau: 1000
+    dataloader_core: "TauMLTools/Training/interface/DataLoader_main.h"
+    debug: False
   SetupNN:
     n_batches: -1
     n_batches_val: -1

--- a/Evaluation/eval_tools.py
+++ b/Evaluation/eval_tools.py
@@ -323,7 +323,7 @@ def prepare_filelists(sample_alias, path_to_input, path_to_pred, path_to_target,
             i = basename.split('_')[-2]
         else:
             i = basename.split('_')[-1]
-        return int(i)
+        return i
         
     # prepare list of files with inputs
     if path_to_input is not None:

--- a/Training/interface/DataLoader_main.h
+++ b/Training/interface/DataLoader_main.h
@@ -104,7 +104,7 @@ struct Data {
          size_t n_outer_cells, size_t globalgrid_fn, size_t pfelectron_fn, size_t pfmuon_fn,
          size_t pfchargedhad_fn, size_t pfneutralhad_fn, size_t pfgamma_fn,
          size_t electron_fn, size_t muon_fn, size_t tau_labels) :
-         x_tau(n_tau * tau_fn, 0), weight(n_tau, 0), y_onehot(n_tau * tau_labels, 0)
+         filled_tau(0), x_tau(n_tau * tau_fn, 0), weight(n_tau, 0), y_onehot(n_tau * tau_labels, 0)
          {
            x_grid[CellObjectType::GridGlobal][0].resize(n_tau * n_outer_cells * n_outer_cells * globalgrid_fn,0);
            x_grid[CellObjectType::GridGlobal][1].resize(n_tau * n_inner_cells * n_inner_cells * globalgrid_fn,0);
@@ -130,7 +130,7 @@ struct Data {
            x_grid[CellObjectType::Muon][0].resize(n_tau * n_outer_cells * n_outer_cells * muon_fn,0);
            x_grid[CellObjectType::Muon][1].resize(n_tau * n_inner_cells * n_inner_cells * muon_fn,0);
          }
-
+    size_t filled_tau; // the number of taus filled in the tensor filled_tau <= n_tau;
     std::vector<float> x_tau;
     GridMap x_grid; // [enum class CellObjectType][ 0 - outer, 1 - inner]
     std::vector<float> weight;
@@ -261,14 +261,15 @@ public:
           if (!tau_is_set && include_mismatched)
             ++tau_i;
           ++current_entry;
+          data->filled_tau = tau_i;
         }
         fullData = true;
         return true;
     }
 
-    const Data* LoadData() {
-      if(!fullData)
-        throw std::runtime_error("Data was not loaded with MoveNext()");
+    const Data* LoadData(bool needFull) {
+      if(!fullData && needFull)
+        throw std::runtime_error("Data was not loaded with MoveNext() or array was not fully filled");
       fullData = false;
       hasData = false;
       return data.get();

--- a/Training/interface/DataLoader_main.h
+++ b/Training/interface/DataLoader_main.h
@@ -269,6 +269,8 @@ public:
         return true;
     }
 
+    bool hasAnyData() {return hasData;}
+
     const Data* LoadData(bool needFull) {
       if(!fullData && needFull)
         throw std::runtime_error("Data was not loaded with MoveNext() or array was not fully filled");

--- a/Training/python/2018v1/Training_test.py
+++ b/Training/python/2018v1/Training_test.py
@@ -9,7 +9,7 @@ import DataLoader
 
 with open(os.path.abspath( "../../configs/training_v1.yaml")) as f:
     config = yaml.safe_load(f)
-scaling  = os.path.abspath("../../configs/ShuffleMergeSpectral_trainingSamples-2_files_0_50.json")
+scaling  = os.path.abspath("../../configs/ShuffleMergeSpectral_trainingSamples-2_rerun_files_0_19.json")
 dataloader = DataLoader.DataLoader(config, scaling)
 
 gen_train = dataloader.get_generator(primary_set = True)
@@ -20,7 +20,7 @@ input_shape, input_types = dataloader.get_input_config()
 
 data_train = tf.data.Dataset.from_generator(
     gen_train, output_types = input_types, output_shapes = input_shape
-    ).prefetch(10)
+    ).prefetch(tf.data.AUTOTUNE)
 
 time_checkpoints = [time.time()]
 

--- a/Training/python/2018v1/Training_test.py
+++ b/Training/python/2018v1/Training_test.py
@@ -24,13 +24,13 @@ data_train = tf.data.Dataset.from_generator(
 
 time_checkpoints = [time.time()]
 
-for epoch in range(3):
+for epoch in range(1):
     print("Epoch ->", epoch)
-    for i,_ in enumerate(data_train):
+    for i,X in enumerate(data_train):
         # if i % 10 == 0:
         #     time.sleep(10)
         time_checkpoints.append(time.time())
-        print(i, " ", time_checkpoints[-1]-time_checkpoints[-2], "s.")
+        print(i, " ", time_checkpoints[-1]-time_checkpoints[-2], "s.", X[0][0].shape[0])
     
 # for i,_ in enumerate(gen_train()):
 #     time_checkpoints.append(time.time())

--- a/Training/python/2018v1/train.yaml
+++ b/Training/python/2018v1/train.yaml
@@ -10,7 +10,7 @@ path_to_mlflow: mlruns
 experiment_name: ???
 
 # setup
-scaling_cfg: ../../configs/ShuffleMergeSpectral_trainingSamples-2_files_0_50.json # for DataLoader initialisation
+scaling_cfg: ../../configs/ShuffleMergeSpectral_trainingSamples-2_rerun_files_0_19.json # for DataLoader initialisation
 gpu_cfg:
   gpu_mem  : 7 # in Gb
   gpu_index: 0

--- a/Training/python/2018v1/train.yaml
+++ b/Training/python/2018v1/train.yaml
@@ -10,7 +10,7 @@ path_to_mlflow: mlruns
 experiment_name: ???
 
 # setup
-scaling_cfg: ../../configs/ShuffleMergeSpectral_trainingSamples-2_rerun_files_0_19.json # for DataLoader initialisation
+scaling_cfg: ../../configs/ShuffleMergeSpectral_trainingSamples-2_files_0_498.json # for DataLoader initialisation
 gpu_cfg:
   gpu_mem  : 7 # in Gb
   gpu_index: 0

--- a/Training/python/DataLoader_test.py
+++ b/Training/python/DataLoader_test.py
@@ -67,17 +67,17 @@ data_que = Queue(maxsize = n_batches_store)
 
 times = []
 
-def getdata(_obj_f, filled_tau, _reshape, _dtype=np.float32):
+def getdata(_obj_f, tau_i, _reshape, _dtype=np.float32):
     x = np.copy(np.frombuffer(_obj_f.data(), dtype=_dtype, count=_obj_f.size()))
-    return x[:filled_tau] if _reshape==-1 else x.reshape(_reshape)[:filled_tau]
+    return x[:tau_i] if _reshape==-1 else x.reshape(_reshape)[:tau_i]
 
-def getgrid(_obj_grid, filled_tau, _inner):
+def getgrid(_obj_grid, tau_i, _inner):
     _n_cells = n_inner_cells if _inner else n_outer_cells
     _X = []
     for group in input_grids:
         _X.append(
             np.concatenate(
-                [ getdata(_obj_grid[ getattr(R.CellObjectType,fname) ][_inner], filled_tau,
+                [ getdata(_obj_grid[ getattr(R.CellObjectType,fname) ][_inner], tau_i,
                     (n_tau, _n_cells, _n_cells, n_grid_features[fname])) for fname in group ],
                 axis=-1
                 )
@@ -105,16 +105,16 @@ for i in range(n_batches):
     data = data_loader.LoadData(checker)
 
     # Flat Tau features
-    X = [getdata(data.x_tau, data.filled_tau, (n_tau, n_fe_tau))]
+    X = [getdata(data.x_tau, data.tau_i, (n_tau, n_fe_tau))]
     # Inner grid
-    X += getgrid(data.x_grid, data.filled_tau, 1) # 500 11 11 176
+    X += getgrid(data.x_grid, data.tau_i, 1) # 500 11 11 176
     # Outer grid
-    X += getgrid(data.x_grid, data.filled_tau, 0) # 500 21 21 176
+    X += getgrid(data.x_grid, data.tau_i, 0) # 500 21 21 176
 
     X = tuple(X)
 
-    weights = getdata(data.weight, data.filled_tau, -1)
-    Y = getdata(data.y_onehot, data.filled_tau, (n_tau, tau_types))
+    weights = getdata(data.weight, data.tau_i, -1)
+    Y = getdata(data.y_onehot, data.tau_i, (n_tau, tau_types))
 
 
     data_que.put(X)

--- a/Training/python/DataLoader_test.py
+++ b/Training/python/DataLoader_test.py
@@ -15,7 +15,7 @@ print("Compiling Setup classes...")
 
 with open(os.path.abspath( "../configs/training_v1.yaml")) as f:
     config = yaml.safe_load(f)
-R.gInterpreter.Declare(config_parse.create_scaling_input("../configs/scaling_params_v1.json", config, verbose=False))
+R.gInterpreter.Declare(config_parse.create_scaling_input("../configs/ShuffleMergeSpectral_trainingSamples-2_rerun_files_0_19.json", config, verbose=False))
 R.gInterpreter.Declare(config_parse.create_settings(config, verbose=False))
 
 print("Compiling DataLoader_main...")
@@ -59,7 +59,7 @@ for root, dirs, files in os.walk(os.path.abspath(R.Setup.input_dir)):
 
 data_loader = R.DataLoader()
 
-n_batches = 1000
+n_batches = 10000
 n_batches_store = 5
 
 from queue import Queue
@@ -67,17 +67,17 @@ data_que = Queue(maxsize = n_batches_store)
 
 times = []
 
-def getdata(_obj_f, _reshape, _dtype=np.float32):
+def getdata(_obj_f, filled_tau, _reshape, _dtype=np.float32):
     x = np.copy(np.frombuffer(_obj_f.data(), dtype=_dtype, count=_obj_f.size()))
-    return x if _reshape==-1 else x.reshape(_reshape)
+    return x[:filled_tau] if _reshape==-1 else x.reshape(_reshape)[:filled_tau]
 
-def getgrid(_obj_grid, _inner):
+def getgrid(_obj_grid, filled_tau, _inner):
     _n_cells = n_inner_cells if _inner else n_outer_cells
     _X = []
     for group in input_grids:
         _X.append(
             np.concatenate(
-                [ getdata(_obj_grid[ getattr(R.CellObjectType,fname) ][_inner],
+                [ getdata(_obj_grid[ getattr(R.CellObjectType,fname) ][_inner], filled_tau,
                     (n_tau, _n_cells, _n_cells, n_grid_features[fname])) for fname in group ],
                 axis=-1
                 )
@@ -102,20 +102,19 @@ for i in range(n_batches):
        c+=1
        continue
 
-    data = data_loader.LoadData()
-
+    data = data_loader.LoadData(checker)
 
     # Flat Tau features
-    X = [getdata(data.x_tau, (n_tau, n_fe_tau))]
+    X = [getdata(data.x_tau, data.filled_tau, (n_tau, n_fe_tau))]
     # Inner grid
-    X += getgrid(data.x_grid, 1) # 500 11 11 176
+    X += getgrid(data.x_grid, data.filled_tau, 1) # 500 11 11 176
     # Outer grid
-    X += getgrid(data.x_grid, 0) # 500 21 21 176
+    X += getgrid(data.x_grid, data.filled_tau, 0) # 500 21 21 176
 
     X = tuple(X)
 
-    weights = getdata(data.weight, -1)
-    Y = getdata(data.y_onehot, (n_tau, tau_types))
+    weights = getdata(data.weight, data.filled_tau, -1)
+    Y = getdata(data.y_onehot, data.filled_tau, (n_tau, tau_types))
 
 
     data_que.put(X)
@@ -132,6 +131,9 @@ for i in range(n_batches):
             print("Inf detected! element=",x.shape)
         if np.amax(x)==0:
             print("Empty tuple detected! element=",x.shape)
+
+    if(checker==False):
+        break
 
 from statistics import mean
 print("Mean time: ", mean(times))


### PR DESCRIPTION
This fix in the core is aiming to modify two aspects:

Issue with inconsistent number of batches in different epochs:
- [x] Allow to load tensors with not fully filled taus in LoadData() function
- [x] Crop input tensor correspondingly to this number in the DataLoader base
- [x] Modify QueueEx and DataSource classes in order to collect the rests on the last iteration and repack them by n taus * n times + rests * 1 time (to allow use all the taus available)
- [ ] Propagate changes to the Reco study

Unimaginably large loading time for get_predict_generator:
- [x] Allow get_predict_generator load by n_taus for n_taus >> 1 + a bit less on last iteration (with this fix loading one file [GluGluHToTauTau_M125/eventTuple_1-10.root] is taking by apply_training.py in **~10min**)
- [x] Allow masking of taus with undefined type when model.predict(X) in apply_training.py - will bring few more times speed up for the MC when we have a lot of not matched to TauType candidates.     