### PR TITLE
Boosted Tau Production Changes for Ultra Legacy

### DIFF
--- a/Production/plugins/BoostedTauProductionFilter.cc
+++ b/Production/plugins/BoostedTauProductionFilter.cc
@@ -1,0 +1,156 @@
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+#include "DataFormats/PatCandidates/interface/Tau.h"
+
+//
+// class declaration
+//
+
+class BoostedTauProductionFilter : public edm::stream::EDFilter<> {
+   public:
+      explicit BoostedTauProductionFilter(const edm::ParameterSet&);
+      ~BoostedTauProductionFilter();
+
+      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+   private:
+      virtual void beginStream(edm::StreamID) override;
+      virtual bool filter(edm::Event&, const edm::EventSetup&) override;
+      virtual void endStream() override;
+
+      //virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
+      //virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
+      //virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+      //virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+
+      // ----------member data ---------------------------
+  edm::EDGetTokenT< std::vector<pat::Tau> > boostedTauCollection;
+  bool verboseDebug;
+};
+
+//
+// constants, enums and typedefs
+//
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+BoostedTauProductionFilter::BoostedTauProductionFilter(const edm::ParameterSet& iConfig):
+  boostedTauCollection(consumes< std::vector<pat::Tau> >(iConfig.getParameter< edm::InputTag >("boostedTauCollection") ) )
+{
+   //now do what ever initialization is needed
+  verboseDebug = iConfig.exists("verboseDebug") ? iConfig.getParameter<bool>("verboseDebug"): false;
+  if (verboseDebug) std::cout<<"Constructing boosted tau filter..."<<std::endl;
+}
+
+
+BoostedTauProductionFilter::~BoostedTauProductionFilter()
+{
+ 
+   // do anything here that needs to be done at destruction time
+   // (e.g. close files, deallocate resources etc.)
+
+}
+
+
+//
+// member functions
+//
+
+// ------------ method called on each new Event  ------------
+bool
+BoostedTauProductionFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+   using namespace edm;
+   /*
+#ifdef THIS_IS_AN_EVENT_EXAMPLE
+   Handle<ExampleData> pIn;
+   iEvent.getByLabel("example",pIn);
+#endif
+
+#ifdef THIS_IS_AN_EVENTSETUP_EXAMPLE
+   ESHandle<SetupData> pSetup;
+   iSetup.get<SetupRecord>().get(pSetup);
+#endif
+   return true;
+   */
+
+   edm::Handle< std::vector<pat::Tau> > boostedTauHandle;
+   iEvent.getByToken(boostedTauCollection, boostedTauHandle);
+
+   //Our filter really only asks one very simple question. Is there a boosted tau in the event?
+   if (verboseDebug) std::cout<<"boosted taus empty? "<<boostedTauHandle->empty()<<std::endl;
+   if (boostedTauHandle->empty()) return false;
+   return true;
+   
+   
+}
+
+// ------------ method called once each stream before processing any runs, lumis or events  ------------
+void
+BoostedTauProductionFilter::beginStream(edm::StreamID)
+{
+}
+
+// ------------ method called once each stream after processing all runs, lumis and events  ------------
+void
+BoostedTauProductionFilter::endStream() {
+}
+
+// ------------ method called when starting to processes a run  ------------
+/*
+void
+BoostedTauProductionFilter::beginRun(edm::Run const&, edm::EventSetup const&)
+{ 
+}
+*/
+ 
+// ------------ method called when ending the processing of a run  ------------
+/*
+void
+BoostedTauProductionFilter::endRun(edm::Run const&, edm::EventSetup const&)
+{
+}
+*/
+ 
+// ------------ method called when starting to processes a luminosity block  ------------
+/*
+void
+BoostedTauProductionFilter::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
+{
+}
+*/
+ 
+// ------------ method called when ending the processing of a luminosity block  ------------
+/*
+void
+BoostedTauProductionFilter::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
+{
+}
+*/
+ 
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void
+BoostedTauProductionFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+//define this as a plug-in
+DEFINE_FWK_MODULE(BoostedTauProductionFilter);

--- a/Production/python/Production.py
+++ b/Production/python/Production.py
@@ -39,7 +39,7 @@ options.register('reclusterJets', True, VarParsing.multiplicity.singleton, VarPa
 options.register('rerunTauReco', False, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
                 "If true, tau reconstruction is re-run on MINIAOD with a larger signal cone and no DM finding filter")
 options.register('useBoostedTauFilter', False, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
-                 "Implement boosted tau filter in the boosted the process to get boosted tau enriched files.")
+                 "Implement boosted tau filter in the process to only consider events with some boosted tau content")
 options.parseArguments()
 
 sampleConfig = importlib.import_module('TauMLTools.Production.sampleConfig')

--- a/Production/python/Production.py
+++ b/Production/python/Production.py
@@ -115,24 +115,6 @@ if isPhase2:
     tauIdEmbedder.runTauID() # note here, that with the official CMSSW version of 'runTauIdMVA' slimmedTaus are hardcoded as input tau collection
     boostedTaus_InputTag = cms.InputTag('slimmedTausBoosted')
 elif isRun2UL:
-    #this reruns the ID process...
-    #but this shouldn't be necessary for UL
-    """
-    from TauMLTools.Production.runTauIdMVA import runTauID
-    from RecoTauTag.Configuration.boostedHPSPFTaus_cff import ca8PFJetsCHSprunedForBoostedTaus
-    process.ca8PFJetsCHSprunedForBoostedTausPAT = ca8PFJetsCHSprunedForBoostedTaus.clone(
-        src = cms.InputTag("packedPFCandidates"),
-        jetCollInstanceName = cms.string('subJetsForSeedingBoostedTausPAT')
-    )
-    updatedBoostedTauName = "slimmedBoostedTausNewID"
-    runTauID(process, outputTauCollection=updatedBoostedTauName, inputTauCollection="slimmedTausBoosted",
-             toKeep = [ "2017v2", "dR0p32017v2", "newDM2017v2", "deepTau2017v2p1" ])
-    process.boostedSequence = cms.Sequence(
-        process.ca8PFJetsCHSprunedForBoostedTausPAT *
-        getattr(process, updatedBoostedTauName + 'rerunMvaIsolationSequence') *
-        getattr(process, updatedBoostedTauName))
-    boostedTaus_InputTag = cms.InputTag(updatedBoostedTauName)    
-    """
     boostedTaus_InputTag = cms.InputTag("slimmedTausBoosted")    
 else:    
     from TauMLTools.Production.runTauIdMVA import runTauID

--- a/Production/python/Production.py
+++ b/Production/python/Production.py
@@ -115,6 +115,7 @@ if isPhase2:
 elif isRun2UL:
     boostedTaus_InputTag = cms.InputTag('slimmedTausBoosted')
 else:
+    
     from TauMLTools.Production.runTauIdMVA import runTauID
     updatedTauName = "slimmedTausNewID"
     runTauID(process, outputTauCollection = updatedTauName, inputTauCollection = tau_collection,
@@ -134,7 +135,6 @@ else:
         ca8JetSrc = cms.InputTag('ca8PFJetsCHSprunedForBoostedTausPAT','subJetsForSeedingBoostedTausPAT'),
         removeOverLap = cms.bool(True),
     )
-
     updatedBoostedTauName = "slimmedBoostedTausNewID"
     runTauID(process, outputTauCollection=updatedBoostedTauName, inputTauCollection="cleanedSlimmedTausBoosted",
              toKeep = [ "2017v2", "dR0p32017v2", "newDM2017v2", "deepTau2017v2p1" ])
@@ -153,8 +153,7 @@ else:
         process.ca8PFJetsCHSprunedForBoostedTausPAT *
         getattr(process, updatedBoostedTauName + 'rerunMvaIsolationSequence') *
         getattr(process, updatedBoostedTauName))
-    boostedTaus_InputTag = cms.InputTag(updatedBoostedTauName)
-
+    boostedTaus_InputTag = cms.InputTag(updatedBoostedTauName)    
 
 # boostedTaus_InputTag = cms.InputTag('slimmedTausBoosted')
 if isRun2UL:
@@ -246,6 +245,14 @@ if isPhase2:
 
 if isRun2PreUL:
     process.p.insert(2, process.boostedSequence)
+
+if (options.sampleType == "UL16"
+    or options.sampleType == "UL16APV"
+    or options.sampleType == "UL17"
+    or options.sampletype == "UL18"):
+    print("inserting boosted tau sequence")
+    process.p.insert(2, process.boostedSequence)
+    
 
 process.load('FWCore.MessageLogger.MessageLogger_cfi')
 x = process.maxEvents.input.value()

--- a/Production/python/Production.py
+++ b/Production/python/Production.py
@@ -126,6 +126,7 @@ else:
         src = cms.InputTag("packedPFCandidates"),
         jetCollInstanceName = cms.string('subJetsForSeedingBoostedTausPAT')
     )
+    """
     process.cleanedSlimmedTausBoosted = cms.EDProducer("PATBoostedTauCleaner",
         src = cms.InputTag('slimmedTausBoosted'),
         pfcands = cms.InputTag('packedPFCandidates'),
@@ -144,6 +145,16 @@ else:
         getattr(process, updatedBoostedTauName + 'rerunMvaIsolationSequence') *
         getattr(process, updatedBoostedTauName))
     boostedTaus_InputTag = cms.InputTag(updatedBoostedTauName)
+    """
+    updatedBoostedTauName = "slimmedBoostedTausNewID"
+    runTauID(process, outputTauCollection=updatedBoostedTauName, inputTauCollection="slimmedTausBoosted",
+             toKeep = [ "2017v2", "dR0p32017v2", "newDM2017v2", "deepTau2017v2p1" ])
+    process.boostedSequence = cms.Sequence(
+        process.ca8PFJetsCHSprunedForBoostedTausPAT *
+        getattr(process, updatedBoostedTauName + 'rerunMvaIsolationSequence') *
+        getattr(process, updatedBoostedTauName))
+    boostedTaus_InputTag = cms.InputTag(updatedBoostedTauName)
+
 
 # boostedTaus_InputTag = cms.InputTag('slimmedTausBoosted')
 if isRun2UL:

--- a/Production/python/Production.py
+++ b/Production/python/Production.py
@@ -115,8 +115,8 @@ if isPhase2:
     tauIdEmbedder.runTauID() # note here, that with the official CMSSW version of 'runTauIdMVA' slimmedTaus are hardcoded as input tau collection
     boostedTaus_InputTag = cms.InputTag('slimmedTausBoosted')
 elif isRun2UL:
-    boostedTaus_InputTag = cms.InputTag("slimmedTausBoosted")    
-else:    
+    boostedTaus_InputTag = cms.InputTag('slimmedTausBoosted')
+else:
     from TauMLTools.Production.runTauIdMVA import runTauID
     updatedTauName = "slimmedTausNewID"
     runTauID(process, outputTauCollection = updatedTauName, inputTauCollection = tau_collection,
@@ -135,6 +135,7 @@ else:
         ca8JetSrc = cms.InputTag('ca8PFJetsCHSprunedForBoostedTausPAT','subJetsForSeedingBoostedTausPAT'),
         removeOverLap = cms.bool(True),
     )
+
     updatedBoostedTauName = "slimmedBoostedTausNewID"
     runTauID(process, outputTauCollection=updatedBoostedTauName, inputTauCollection="cleanedSlimmedTausBoosted",
              toKeep = [ "2017v2", "dR0p32017v2", "newDM2017v2", "deepTau2017v2p1" ])

--- a/Production/python/Production.py
+++ b/Production/python/Production.py
@@ -115,9 +115,26 @@ if isPhase2:
     tauIdEmbedder.runTauID() # note here, that with the official CMSSW version of 'runTauIdMVA' slimmedTaus are hardcoded as input tau collection
     boostedTaus_InputTag = cms.InputTag('slimmedTausBoosted')
 elif isRun2UL:
-    boostedTaus_InputTag = cms.InputTag('slimmedTausBoosted')
-else:
-    
+    #this reruns the ID process...
+    #but this shouldn't be necessary for UL
+    """
+    from TauMLTools.Production.runTauIdMVA import runTauID
+    from RecoTauTag.Configuration.boostedHPSPFTaus_cff import ca8PFJetsCHSprunedForBoostedTaus
+    process.ca8PFJetsCHSprunedForBoostedTausPAT = ca8PFJetsCHSprunedForBoostedTaus.clone(
+        src = cms.InputTag("packedPFCandidates"),
+        jetCollInstanceName = cms.string('subJetsForSeedingBoostedTausPAT')
+    )
+    updatedBoostedTauName = "slimmedBoostedTausNewID"
+    runTauID(process, outputTauCollection=updatedBoostedTauName, inputTauCollection="slimmedTausBoosted",
+             toKeep = [ "2017v2", "dR0p32017v2", "newDM2017v2", "deepTau2017v2p1" ])
+    process.boostedSequence = cms.Sequence(
+        process.ca8PFJetsCHSprunedForBoostedTausPAT *
+        getattr(process, updatedBoostedTauName + 'rerunMvaIsolationSequence') *
+        getattr(process, updatedBoostedTauName))
+    boostedTaus_InputTag = cms.InputTag(updatedBoostedTauName)    
+    """
+    boostedTaus_InputTag = cms.InputTag("slimmedTausBoosted")    
+else:    
     from TauMLTools.Production.runTauIdMVA import runTauID
     updatedTauName = "slimmedTausNewID"
     runTauID(process, outputTauCollection = updatedTauName, inputTauCollection = tau_collection,
@@ -129,7 +146,6 @@ else:
         src = cms.InputTag("packedPFCandidates"),
         jetCollInstanceName = cms.string('subJetsForSeedingBoostedTausPAT')
     )
-    """
     process.cleanedSlimmedTausBoosted = cms.EDProducer("PATBoostedTauCleaner",
         src = cms.InputTag('slimmedTausBoosted'),
         pfcands = cms.InputTag('packedPFCandidates'),
@@ -147,15 +163,6 @@ else:
         getattr(process, updatedBoostedTauName + 'rerunMvaIsolationSequence') *
         getattr(process, updatedBoostedTauName))
     boostedTaus_InputTag = cms.InputTag(updatedBoostedTauName)
-    """
-    updatedBoostedTauName = "slimmedBoostedTausNewID"
-    runTauID(process, outputTauCollection=updatedBoostedTauName, inputTauCollection="slimmedTausBoosted",
-             toKeep = [ "2017v2", "dR0p32017v2", "newDM2017v2", "deepTau2017v2p1" ])
-    process.boostedSequence = cms.Sequence(
-        process.ca8PFJetsCHSprunedForBoostedTausPAT *
-        getattr(process, updatedBoostedTauName + 'rerunMvaIsolationSequence') *
-        getattr(process, updatedBoostedTauName))
-    boostedTaus_InputTag = cms.InputTag(updatedBoostedTauName)    
 
 # boostedTaus_InputTag = cms.InputTag('slimmedTausBoosted')
 if isRun2UL:
@@ -246,12 +253,6 @@ if isPhase2:
     process.p.insert(0, process.slimmedElectronsMerged)
 
 if isRun2PreUL:
-    process.p.insert(2, process.boostedSequence)
-
-if (options.sampleType == "UL16"
-    or options.sampleType == "UL16APV"
-    or options.sampleType == "UL17"
-    or options.sampleType == "UL18"):
     process.p.insert(2, process.boostedSequence)
 
 if options.useBoostedTauFilter:

--- a/Production/python/Production.py
+++ b/Production/python/Production.py
@@ -38,6 +38,8 @@ options.register('reclusterJets', True, VarParsing.multiplicity.singleton, VarPa
                 " If 'reclusterJets' set true a new collection of uncorrected ak4PFJets is built to seed taus (as at RECO), otherwise standard slimmedJets are used")
 options.register('rerunTauReco', False, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
                 "If true, tau reconstruction is re-run on MINIAOD with a larger signal cone and no DM finding filter")
+options.register('useBoostedTauFilter', False, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
+                 "Implement boosted tau filter in the boosted the process to get boosted tau enriched files.")
 options.parseArguments()
 
 sampleConfig = importlib.import_module('TauMLTools.Production.sampleConfig')
@@ -249,10 +251,14 @@ if isRun2PreUL:
 if (options.sampleType == "UL16"
     or options.sampleType == "UL16APV"
     or options.sampleType == "UL17"
-    or options.sampletype == "UL18"):
-    print("inserting boosted tau sequence")
+    or options.sampleType == "UL18"):
     process.p.insert(2, process.boostedSequence)
-    
+
+if options.useBoostedTauFilter:
+    process.theBoostedTauFilter = cms.EDFilter('BoostedTauProductionFilter',
+                                               boostedTauCollection = cms.InputTag("slimmedTausBoosted"),
+                                               verboseDebug = cms.bool(False))
+    process.p.insert(0, process.theBoostedTauFilter)
 
 process.load('FWCore.MessageLogger.MessageLogger_cfi')
 x = process.maxEvents.input.value()

--- a/Production/python/runTauIdMVA.py
+++ b/Production/python/runTauIdMVA.py
@@ -84,10 +84,8 @@ def runTauID(process, outputTauCollection='slimmedTausNewID', inputTauCollection
             srcFootprintCorrection = 'footprintCorrectiondR03'
             srcPhotonPtSumOutsideSignalCone = 'photonPtSumOutsideSignalConedR03'
         elif isBoosted:
-            #srcChargedIsoPtSum = 'chargedIsoPtSumNoOverLap'
-            #srcNeutralIsoPtSum = 'neutralIsoPtSumNoOverLap'
-            srcChargedIsoPtSum = 'chargedIsoPtSum'
-            srcNeutralIsoPtSum = 'neutralIsoPtSum'
+            srcChargedIsoPtSum = 'chargedIsoPtSumNoOverLap'
+            srcNeutralIsoPtSum = 'neutralIsoPtSumNoOverLap'
             srcFootprintCorrection = 'footprintCorrection'
             srcPhotonPtSumOutsideSignalCone = 'photonPtSumOutsideSignalCone'
         else:

--- a/Production/python/runTauIdMVA.py
+++ b/Production/python/runTauIdMVA.py
@@ -84,8 +84,10 @@ def runTauID(process, outputTauCollection='slimmedTausNewID', inputTauCollection
             srcFootprintCorrection = 'footprintCorrectiondR03'
             srcPhotonPtSumOutsideSignalCone = 'photonPtSumOutsideSignalConedR03'
         elif isBoosted:
-            srcChargedIsoPtSum = 'chargedIsoPtSumNoOverLap'
-            srcNeutralIsoPtSum = 'neutralIsoPtSumNoOverLap'
+            #srcChargedIsoPtSum = 'chargedIsoPtSumNoOverLap'
+            #srcNeutralIsoPtSum = 'neutralIsoPtSumNoOverLap'
+            srcChargedIsoPtSum = 'chargedIsoPtSum'
+            srcNeutralIsoPtSum = 'neutralIsoPtSum'
             srcFootprintCorrection = 'footprintCorrection'
             srcPhotonPtSumOutsideSignalCone = 'photonPtSumOutsideSignalCone'
         else:

--- a/Production/python/sampleConfig.py
+++ b/Production/python/sampleConfig.py
@@ -6,7 +6,7 @@ import FWCore.ParameterSet.Config as cms
 import os
 
 mcSampleTypes = Set([ 'MC_16', 'MC_17', 'MC_18', 'MC_UL18', 'Emb_16', 'Emb_17', 'Emb_18ABC', 'Emb_18D', 'MC_Phase2_111X', 'MC_Phase2_110X', 'UL18', 'UL17','UL16','UL16APV'])
-dataSampleTypes = Set([ 'Run2016' , 'Run2017', 'Run2018ABC', 'Run2018D' ])
+dataSampleTypes = Set([ 'Run2016' , 'Run2017', 'Run2018ABC', 'Run2018D', 'RunUL2018' ])
 
 periodDict = { 'MC_16' : 'Run2016',
                'Run2016' : 'Run2016',

--- a/Production/python/sampleConfig.py
+++ b/Production/python/sampleConfig.py
@@ -5,8 +5,8 @@ from sets import Set
 import FWCore.ParameterSet.Config as cms
 import os
 
-mcSampleTypes = Set([ 'MC_16', 'MC_17', 'MC_18', 'MC_UL18', 'Emb_16', 'Emb_17', 'Emb_18ABC', 'Emb_18D', 'MC_Phase2_111X', 'MC_Phase2_110X'])
-dataSampleTypes = Set([ 'Run2016' , 'Run2017', 'Run2018ABC', 'Run2018D', 'RunUL2018' ])
+mcSampleTypes = Set([ 'MC_16', 'MC_17', 'MC_18', 'MC_UL18', 'Emb_16', 'Emb_17', 'Emb_18ABC', 'Emb_18D', 'MC_Phase2_111X', 'MC_Phase2_110X', 'UL18', 'UL17','UL16','UL16APV'])
+dataSampleTypes = Set([ 'Run2016' , 'Run2017', 'Run2018ABC', 'Run2018D' ])
 
 periodDict = { 'MC_16' : 'Run2016',
                'Run2016' : 'Run2016',
@@ -23,6 +23,10 @@ periodDict = { 'MC_16' : 'Run2016',
                'Emb_18D' : 'Run2018',
                'MC_Phase2_110X' : 'Phase2',
                'MC_Phase2_111X' : 'Phase2',
+               'UL18': 'Run2018',
+               'UL17': 'Run2017',
+               'UL16': 'Run2016',
+               'UL16APV': 'Run2016',
              }
 
 globalTagMap = { 'MC_16' : '102X_mcRun2_asymptotic_v7',
@@ -41,6 +45,10 @@ globalTagMap = { 'MC_16' : '102X_mcRun2_asymptotic_v7',
                  'Emb_18D' : '102X_dataRun2_Prompt_v15',
                  'MC_Phase2_110X' : '110X_mcRun4_realistic_v3',
                  'MC_Phase2_111X' : 'auto:phase2_realistic_T15',
+                 'UL18': '106X_upgrade2018_realistic_v15_L1v1',
+                 'UL17': '106X_mc2017_realistic_v8',
+                 'UL16': '106X_mcRun2_asymptotic_v17',
+                 'UL16APV': '106X_mcRun2_asymptotic_preVFP_v11 '
                }
 
 def IsEmbedded(sampleType):

--- a/Production/python/sampleConfig.py
+++ b/Production/python/sampleConfig.py
@@ -81,7 +81,7 @@ def isRun2UL(sampleType):
     if sampleType not in periodDict:
         print "ERROR: unknown sample type = '{}'".format(sampleType)
         sys.exit(1)
-    return sampleType in ['MC_UL18', 'RunUL2018']
+    return sampleType in ['MC_UL18', 'RunUL2018', 'UL16', 'UL16APV', 'UL17', 'UL18']
 
 def isPhase2(sampleType):
     if sampleType not in periodDict:

--- a/Production/python/sampleConfig.py
+++ b/Production/python/sampleConfig.py
@@ -48,7 +48,7 @@ globalTagMap = { 'MC_16' : '102X_mcRun2_asymptotic_v7',
                  'UL18': '106X_upgrade2018_realistic_v15_L1v1',
                  'UL17': '106X_mc2017_realistic_v8',
                  'UL16': '106X_mcRun2_asymptotic_v17',
-                 'UL16APV': '106X_mcRun2_asymptotic_preVFP_v11 '
+                 'UL16APV': '106X_mcRun2_asymptotic_preVFP_v11'
                }
 
 def IsEmbedded(sampleType):


### PR DESCRIPTION
After some particularly circuitous commits adding some hacks and then removing them, this is the current status of the boosted tau effort UL production. The only real changes after the added and removed hacks is the introduction of some sample types and global tags, and a change to the `isRun2UL` function. For Boosted Tau convenience I have added a quick filter that can be added into the production that simply checks that there is some boosted tau in the collection before attempting to do any Ntuplization, but if this is not desirable in the main repository, it can be removed from the commit.

We will be attempting to make ntuples from all 4 UL time periods under this setup.

I will open a PR for the general boosted tau changes, but that similarly needs to be cleaned up to prevent superfluous merge conflicts from distracting from genuine ones.