### PR TITLE
TensorFlow DataSet Compatibility + other bug fixes

### DIFF
--- a/Evaluation/eval_tools.py
+++ b/Evaluation/eval_tools.py
@@ -323,7 +323,7 @@ def prepare_filelists(sample_alias, path_to_input, path_to_pred, path_to_target,
             i = basename.split('_')[-2]
         else:
             i = basename.split('_')[-1]
-        return int(i)
+        return i
         
     # prepare list of files with inputs
     if path_to_input is not None:

--- a/Evaluation/eval_tools.py
+++ b/Evaluation/eval_tools.py
@@ -323,7 +323,7 @@ def prepare_filelists(sample_alias, path_to_input, path_to_pred, path_to_target,
             i = basename.split('_')[-2]
         else:
             i = basename.split('_')[-1]
-        return i
+        return int(i)
         
     # prepare list of files with inputs
     if path_to_input is not None:

--- a/Training/configs/training_v1.yaml
+++ b/Training/configs/training_v1.yaml
@@ -11,7 +11,7 @@ Setup:
 
     # tau_types_names.keys are written in accordance with tauType in the tau tuple
     tau_types_names      : { "0":"e", "1":"mu", "2":"tau", "3":"jet" }
-    DeepTauVSjet_cut     : -1.0 # WARNING: If set to -1, conversion to C++ fails
+    DeepTauVSjet_cut     : -1.0 
     recompute_tautype    : True
     include_mismatched   : False # whether to keep tau candidates with tau_type not present in `tau_types_names`
     input_dir            : "/eos/cms/store/group/phys_tau/TauML/prod_2018_v2/ShuffleMergeSpectral_trainingSamples-2_rerun/"
@@ -20,8 +20,8 @@ Setup:
     weight_thr           : 100000.0
     dataloader_core      : "TauMLTools/Training/interface/DataLoader_main.h"
     rm_inner_from_outer  : False
-    input_type           : "tf" # supported 'ROOT' or 'tf'
-    tf_input_dir         : "/home/russell/tfdata/emb_21k_99cut"
+    input_type           : "ROOT" # supported 'ROOT' or 'tf'
+    tf_input_dir         : "/home/russell/tfdata/emb_21k_99cut" # path to saved tf dataset
 
     # here define variables for the Histogram_2D class
     yaxis                : [

--- a/Training/configs/training_v1.yaml
+++ b/Training/configs/training_v1.yaml
@@ -21,7 +21,8 @@ Setup:
     dataloader_core      : "TauMLTools/Training/interface/DataLoader_main.h"
     rm_inner_from_outer  : False
     input_type           : "ROOT" # supported 'ROOT' or 'tf'
-    tf_input_dir         : "/home/russell/tfdata/emb_21k_99cut" # path to saved tf dataset
+    tf_input_dir         : "/eos/cms/store/group/phys_tau/TauML/prod_2018_v2/tf_datasets/emb_21k_99cut" # path to saved tf dataset
+    tf_dataset_x_order   : ["TauFlat", "inner_egamma", "inner_muon", "inner_hadron", "outer_egamma", "outer_muon", "outer_hadron"] # specify order of layers in tf dataset
 
     # here define variables for the Histogram_2D class
     yaxis                : [

--- a/Training/configs/training_v1.yaml
+++ b/Training/configs/training_v1.yaml
@@ -20,6 +20,8 @@ Setup:
     weight_thr           : 100000.0
     dataloader_core      : "TauMLTools/Training/interface/DataLoader_main.h"
     rm_inner_from_outer  : False
+    input_type           : "tf" # supported 'ROOT' or 'tf'
+    tf_input_dir         : "/home/russell/tfdata/emb_21k_99cut"
 
     # here define variables for the Histogram_2D class
     yaxis                : [

--- a/Training/interface/DataLoader_main.h
+++ b/Training/interface/DataLoader_main.h
@@ -190,10 +190,10 @@ public:
         input_histogram .th2d_add(*(input_th2d .get()));
 
         target_histogram.divide(input_histogram);
-        hist_weights[tau_type] = std::make_shared<TH2D>(target_histogram.get_weights_th2d(
+        hist_weights[tau_type] = target_histogram.get_weights_th2d(
             ("w_1_"+tau_name).c_str(),
             ("w_1_"+tau_name).c_str()
-        ));
+        );
         if (debug) hist_weights[tau_type]->SaveAs(("Temp_"+tau_name+".root").c_str()); // It's required that all bins are filled in these histograms; save them to check incase binning is too fine and some bins are empty
 
         target_histogram.reset();

--- a/Training/interface/DataLoader_main.h
+++ b/Training/interface/DataLoader_main.h
@@ -776,7 +776,7 @@ public:
             fillGrid(Br::muon_dphi, DeltaPhi(tau.muon_phi.at(idx), tau.tau_phi));
 
             fillGrid(Br::muon_dxy, tau.muon_dxy.at(idx));
-            if(tau.muon_dxy_error.at(idx) != 0)
+            if(std::isnormal(tau.muon_dxy_error.at(idx)) && std::isnormal(tau.muon_dxy.at(idx))) 
               fillGrid(Br::muon_dxy_sig, std::abs(tau.muon_dxy.at(idx)) / tau.muon_dxy_error.at(idx));
 
             const bool normalizedChi2_valid = tau.muon_normalizedChi2.at(idx) >= 0;

--- a/Training/interface/histogram2d.h
+++ b/Training/interface/histogram2d.h
@@ -30,7 +30,7 @@ class Histogram_2D{
     void print(const char* dir);
 
     //use this function only for weights, not for counts
-    TH2D& get_weights_th2d(const char* name, const char* title);
+    std::shared_ptr<TH2D> get_weights_th2d(const char* name, const char* title);
 
   private:
     int find_bin_by_value_(const double& y);
@@ -41,7 +41,7 @@ class Histogram_2D{
     std::vector<std::shared_ptr<TH1D>>  yaxis_content_;
     std::vector<bool> occupancy_;
 
-    std::shared_ptr<TH2D> histo_ = std::make_shared<TH2D>();
+    //std::shared_ptr<TH2D> histo_ = std::make_shared<TH2D>();
 
     double xmin_ = std::numeric_limits<float>::max();
     double xmax_ = std::numeric_limits<float>::lowest();
@@ -173,7 +173,7 @@ void Histogram_2D::divide(const Histogram_2D& histo){
   }
 }
 
-TH2D& Histogram_2D::get_weights_th2d(const char* name, const char* title){
+std::shared_ptr<TH2D> Histogram_2D::get_weights_th2d(const char* name, const char* title){
   double xwidthmin = std::numeric_limits<float>::max();
   double ywidthmin = std::numeric_limits<float>::max();
 
@@ -194,7 +194,7 @@ TH2D& Histogram_2D::get_weights_th2d(const char* name, const char* title){
   int ny = (yaxis_.back() - yaxis_.front()) / ywidthmin;
   int nx = (xmax_ - xmin_) / xwidthmin;
 
-  histo_ = std::shared_ptr<TH2D>(new TH2D(name, title, nx, xmin_, xmax_, ny, yaxis_.front(), yaxis_.back()));
+  auto histo_ = std::make_shared<TH2D>(name, title, nx, xmin_, xmax_, ny, yaxis_.front(), yaxis_.back());
 
   for(int iy = 1; iy <= ny; iy++){
   for(int ix = 1; ix <= nx; ix++){
@@ -209,7 +209,7 @@ TH2D& Histogram_2D::get_weights_th2d(const char* name, const char* title){
     histo_->SetBinError  (ix, iy, error  );
   }}
 
-  return *histo_;
+  return histo_;
 }
 
 void Histogram_2D::print(const char* dir){

--- a/Training/interface/histogram2d.h
+++ b/Training/interface/histogram2d.h
@@ -41,7 +41,6 @@ class Histogram_2D{
     std::vector<std::shared_ptr<TH1D>>  yaxis_content_;
     std::vector<bool> occupancy_;
 
-    //std::shared_ptr<TH2D> histo_ = std::make_shared<TH2D>();
 
     double xmin_ = std::numeric_limits<float>::max();
     double xmax_ = std::numeric_limits<float>::lowest();

--- a/Training/python/2018v1/ROOT_to_tf.py
+++ b/Training/python/2018v1/ROOT_to_tf.py
@@ -1,0 +1,47 @@
+import os
+import yaml
+import gc
+import sys
+from glob import glob
+import math
+import numpy as np
+import tensorflow as tf
+os.environ["CUDA_VISIBLE_DEVICES"]="-1"
+sys.path.insert(0, "..")
+from common import *
+import DataLoader
+import argparse
+
+parser = argparse.ArgumentParser(description='Convert ROOT files to TF dataset')
+parser.add_argument('--n_batches', required=True, type=int, help="Number of batches")
+parser.add_argument('--scaling_cfg', required=True, type=str, help="Scaling config")
+parser.add_argument('--save_path', required=True, type=str, help="Save path")
+parser.add_argument('--training_cfg', required=True, type=str, help="Training config")
+args = parser.parse_args()
+
+
+
+save_path = args.save_path # "/home/russell/tfdata/testing"
+scaling_cfg = args.scaling_cfg #"../../configs/ShuffleMergeSpectral_trainingSamples-2_files_0_50.json"
+training_cfg_path = args.training_cfg #../../configs/training_v1.yaml
+
+with open(training_cfg_path) as file:
+    training_cfg = yaml.full_load(file)
+    print("Training Config Loaded")
+
+training_cfg["SetupNN"]["n_batches"]=args.n_batches
+training_cfg["SetupNN"]["n_batches_val"]=0 # only generate training data as train/val split done later in training
+training_cfg["SetupNN"]["validation_split"]=0
+training_cfg["Setup"]["input_type"]="ROOT" # make ROOT so generator loads
+
+
+dataloader = DataLoader.DataLoader(training_cfg, scaling_cfg)
+print("DataLoader Created")
+gen_train = dataloader.get_generator(primary_set = True, return_weights = dataloader.use_weights, show_progress=True) 
+print("Generator Loaded")
+input_shape, input_types = dataloader.get_input_config()
+print("Input shapes and Types acquired")
+data_train = tf.data.Dataset.from_generator(gen_train, output_types = input_types, output_shapes = input_shape).prefetch(tf.data.AUTOTUNE)
+print("Dataset extracted from DataLoader")
+tf.data.experimental.save(data_train, save_path, compression = "GZIP")
+print("Conversion Complete")

--- a/Training/python/2018v1/Training_v0p1.py
+++ b/Training/python/2018v1/Training_v0p1.py
@@ -311,10 +311,9 @@ def run_training(model, data_loader, to_profile, log_suffix):
             outer_size = data_loader.outer_cell_size
             n_inner_right = (n_inner - 1) / 2
             n_outer_right = np.ceil(n_inner_right * inner_size /  outer_size)
-            n_outer_to_remove = n_outer_right*2 + 1
             i_middle = (n_outer-1)/2
-            i_start = int(i_middle - (n_outer_to_remove-1)/2)
-            i_end = int(i_middle + (n_outer_to_remove-1)/2 + 1) # +1 as end index not included
+            i_start = int(i_middle - n_outer_right)
+            i_end = int(i_middle + n_outer_right + 1) # +1 as end index not included
             my_ds = ds.map(lambda x, y, weights: rm_inner(x, y, weights, outer_indices, i_start, i_end))
         else: 
             my_ds = ds

--- a/Training/python/2018v1/Training_v0p1.py
+++ b/Training/python/2018v1/Training_v0p1.py
@@ -205,7 +205,7 @@ def get_n_filters_conv2d(n_input, current_size, window_size, reduction_rate):
     if reduction_rate is None:
         return n_input
     if window_size <= 1 or current_size < window_size:
-        raise RuntineError("Unable to compute number of filters for the next Conv2D layer.")
+        raise RuntimeError("Unable to compute number of filters for the next Conv2D layer.")
     n_filters = ((float(current_size) / float(current_size - window_size + 1)) ** 2) * n_input / reduction_rate
     return int(math.ceil(n_filters))
 

--- a/Training/python/2018v1/Training_v0p1.py
+++ b/Training/python/2018v1/Training_v0p1.py
@@ -181,7 +181,8 @@ def reduce_n_features_1d(input_layer, net_setup, block_name, first_layer_reg = N
 
 def conv_block(prev_layer, filters, kernel_size, net_setup, block_name, n):
     conv = Conv2D(filters, kernel_size, name="{}_conv_{}".format(block_name, n),
-                  kernel_initializer=net_setup.kernel_init)(prev_layer)
+                  kernel_initializer=net_setup.kernel_init,
+                  kernel_regularizer=net_setup.kernel_regularizer)(prev_layer)
     return add_block_ending(net_setup, '{}_{{}}_{}'.format(block_name, n), conv)
 
 def reduce_n_features_2d(input_layer, net_setup, block_name, first_layer_reg = None):

--- a/Training/python/DataLoader.py
+++ b/Training/python/DataLoader.py
@@ -98,7 +98,7 @@ class DataLoader (DataLoaderBase):
         self.active_features = self.config["SetupNN"]["active_features"]
         self.input_type = self.config["Setup"]["input_type"]
         self.tf_input_dir = self.config["Setup"]["tf_input_dir"]
-        
+
         if self.input_type == "ROOT":
             data_files = glob.glob(f'{self.config["Setup"]["input_dir"]}/*.root') 
             self.train_files, self.val_files = \
@@ -171,6 +171,7 @@ class DataLoader (DataLoaderBase):
         '''
         assert self.batch_size == 1
         data_loader = R.DataLoader()
+        converter = torch_to_tf(return_truth=True, return_weights=False)
         def read_from_file(file_path):
             data_loader.ReadFile(R.std.string(file_path), 0, -1)
             while data_loader.MoveNext():
@@ -180,6 +181,7 @@ class DataLoader (DataLoaderBase):
                                  self.n_inner_cells, self.n_outer_cells, self.active_features, self.cell_locations)
                 y = GetData.getdata(data.y_onehot, (self.batch_size, self.tau_types))
                 yield tuple(x), y
+                yield converter((tuple(x),y))
         return read_from_file
 
     @staticmethod

--- a/Training/python/DataLoader.py
+++ b/Training/python/DataLoader.py
@@ -198,8 +198,6 @@ class DataLoader (DataLoaderBase):
         '''
         converter = torch_to_tf(return_truth, return_weights)
         data_loader = R.DataLoader()
-        if convert_torch_to_tf:
-            converter = torch_to_tf(return_truth=True, return_weights=False)
         def read_from_file(file_path):
             data_loader.ReadFile(R.std.string(file_path), 0, -1)
             while True:

--- a/Training/python/DataLoader.py
+++ b/Training/python/DataLoader.py
@@ -98,7 +98,8 @@ class DataLoader (DataLoaderBase):
         self.active_features = self.config["SetupNN"]["active_features"]
         self.input_type = self.config["Setup"]["input_type"]
         self.tf_input_dir = self.config["Setup"]["tf_input_dir"]
-
+        self.tf_dataset_x_order = self.config["Setup"]["tf_dataset_x_order"]
+        
         if self.input_type == "ROOT":
             data_files = glob.glob(f'{self.config["Setup"]["input_dir"]}/*.root') 
             self.train_files, self.val_files = \
@@ -121,7 +122,7 @@ class DataLoader (DataLoaderBase):
         def _generator():
 
             finish_counter = 0
-            if show_progress:
+            if show_progress and n_batches>0:
                 pbar = tqdm(total = n_batches)
 
             queue_files = mp.Queue()
@@ -146,7 +147,7 @@ class DataLoader (DataLoaderBase):
                     finish_counter+=1
                     terminators[item].set()
                 else:
-                    if show_progress:
+                    if show_progress and n_batches>0:
                         pbar.update(1)
                     yield converter(item)
 
@@ -159,7 +160,7 @@ class DataLoader (DataLoaderBase):
 
         return _generator
 
-    def get_predict_generator(self):
+    def get_predict_generator(self, convert = True):
         '''
         The implementation of the deterministic generator
         for suitable use of performance evaluation.
@@ -171,7 +172,8 @@ class DataLoader (DataLoaderBase):
         '''
         assert self.batch_size == 1
         data_loader = R.DataLoader()
-        converter = torch_to_tf(return_truth=True, return_weights=False)
+        if convert:
+            converter = torch_to_tf(return_truth=True, return_weights=False)
         def read_from_file(file_path):
             data_loader.ReadFile(R.std.string(file_path), 0, -1)
             while data_loader.MoveNext():
@@ -180,8 +182,10 @@ class DataLoader (DataLoaderBase):
                                  self.n_flat_features, self.input_grids,
                                  self.n_inner_cells, self.n_outer_cells, self.active_features, self.cell_locations)
                 y = GetData.getdata(data.y_onehot, (self.batch_size, self.tau_types))
-                yield tuple(x), y
-                yield converter((tuple(x),y))
+                if convert:
+                    yield converter((tuple(x),y))
+                else:  
+                    yield tuple(x), y
         return read_from_file
 
     @staticmethod

--- a/Training/python/DataLoader.py
+++ b/Training/python/DataLoader.py
@@ -86,6 +86,8 @@ class DataLoader (DataLoaderBase):
         self.batch_size     = self.config["Setup"]["n_tau"]
         self.n_inner_cells  = self.config["Setup"]["n_inner_cells"]
         self.n_outer_cells  = self.config["Setup"]["n_outer_cells"]
+        self.inner_cell_size = self.config["Setup"]["inner_cell_size"]
+        self.outer_cell_size = self.config["Setup"]["outer_cell_size"]
         self.tau_types      = len(self.config["Setup"]["tau_types_names"])
         self.n_load_workers   = self.config["SetupNN"]["n_load_workers"]
         self.n_batches        = self.config["SetupNN"]["n_batches"]

--- a/Training/python/DataLoader.py
+++ b/Training/python/DataLoader.py
@@ -35,9 +35,9 @@ def LoaderThread(queue_out,
         X_all = tuple(X_all)
 
         if return_weights:
-            weights = GetData.getdata(data.weight, -1, debug_area="weights")
+            weights = GetData.getdata(data.weight, data.tau_i, -1, debug_area="weights")
         if return_truth:
-            Y = GetData.getdata(data.y_onehot, (batch_size, tau_types), debug_area="truth")
+            Y = GetData.getdata(data.y_onehot, data.tau_i, (batch_size, tau_types), debug_area="truth")
 
         if return_truth and return_weights:
             item = (X_all, Y, weights)

--- a/Training/python/DataLoader.py
+++ b/Training/python/DataLoader.py
@@ -1,5 +1,6 @@
 import gc
 import glob
+from tqdm import tqdm
 
 from DataLoaderBase import *
 
@@ -95,16 +96,18 @@ class DataLoader (DataLoaderBase):
         self.cell_locations = self.config["SetupNN"]["cell_locations"]
         self.rm_inner_from_outer = self.config["Setup"]["rm_inner_from_outer"]
         self.active_features = self.config["SetupNN"]["active_features"]
+        self.input_type = self.config["Setup"]["input_type"]
+        self.tf_input_dir = self.config["Setup"]["tf_input_dir"]
+        
+        if self.input_type == "ROOT":
+            data_files = glob.glob(f'{self.config["Setup"]["input_dir"]}/*.root') 
+            self.train_files, self.val_files = \
+                np.split(data_files, [int(len(data_files)*(1-self.validation_split))])
+            print("Files for training:", len(self.train_files))
+            print("Files for validation:", len(self.val_files))
 
-        data_files = glob.glob(f'{self.config["Setup"]["input_dir"]}/*.root')
-        self.train_files, self.val_files = \
-             np.split(data_files, [int(len(data_files)*(1-self.validation_split))])
 
-        print("Files for training:", len(self.train_files))
-        print("Files for validation:", len(self.val_files))
-
-
-    def get_generator(self, primary_set = True, return_truth = True, return_weights = True):
+    def get_generator(self, primary_set = True, return_truth = True, return_weights = True, show_progress = False):
 
         _files = self.train_files if primary_set else self.val_files
         if len(_files)==0:
@@ -118,6 +121,8 @@ class DataLoader (DataLoaderBase):
         def _generator():
 
             finish_counter = 0
+            if show_progress:
+                pbar = tqdm(total = n_batches)
 
             queue_files = mp.Queue()
             [ queue_files.put(file) for file in _files ]
@@ -141,6 +146,8 @@ class DataLoader (DataLoaderBase):
                     finish_counter+=1
                     terminators[item].set()
                 else:
+                    if show_progress:
+                        pbar.update(1)
                     yield converter(item)
 
             queue_out.clear()

--- a/Training/python/DataLoader.py
+++ b/Training/python/DataLoader.py
@@ -25,15 +25,9 @@ def LoaderThread(queue_out,
         X_all = GetData.getX(data, data.tau_i, batch_size, n_grid_features, n_flat_features,
                              input_grids, n_inner_cells, n_outer_cells, active_features, cell_locations)
         if return_weights:
-<<<<<<< HEAD
             weights = GetData.getdata(data.weight, data.tau_i, -1, debug_area="weights")
         if return_truth:
             Y = GetData.getdata(data.y_onehot, data.tau_i, (batch_size, tau_types), debug_area="truth")
-=======
-            weights = GetData.getdata(data.weight, data.tau_i, -1)
-        if return_truth:
-            Y = GetData.getdata(data.y_onehot, data.tau_i, (batch_size, tau_types))
->>>>>>> master
 
         if return_truth and return_weights:
             item = [X_all, Y, weights]
@@ -122,11 +116,7 @@ class DataLoader (DataLoaderBase):
 
 
 
-        print("Files for training:", len(self.train_files))
-        print("Files for validation:", len(self.val_files))
-
-
-    def get_generator(self, primary_set = True, return_truth = True, return_weights = True):
+    def get_generator(self, primary_set = True, return_truth = True, return_weights = True, show_progress = False):
 
         _files = self.train_files if primary_set else self.val_files
         if len(_files)==0:
@@ -138,6 +128,9 @@ class DataLoader (DataLoaderBase):
         converter = torch_to_tf(return_truth, return_weights)
 
         def _generator():
+            
+            if show_progress and n_batches>0:
+                pbar = tqdm(total = n_batches)
 
             queue_files = mp.Queue()
             [ queue_files.put(file) for file in _files ]

--- a/Training/python/DataLoader.py
+++ b/Training/python/DataLoader.py
@@ -160,7 +160,7 @@ class DataLoader (DataLoaderBase):
 
         return _generator
 
-    def get_predict_generator(self, convert_torch_to_tf = True):
+    def get_predict_generator(self, return_truth=True, return_weights=False, convert_torch_to_tf=True):
         '''
         The implementation of the deterministic generator
         for suitable use of performance evaluation.
@@ -181,7 +181,7 @@ class DataLoader (DataLoaderBase):
                 x = GetData.getX(data, self.batch_size, self.n_grid_features,
                                  self.n_flat_features, self.input_grids,
                                  self.n_inner_cells, self.n_outer_cells, self.active_features, self.cell_locations)
-                y = GetData.getdata(data.y_onehot, (self.batch_size, self.tau_types))
+                y = GetData.getdata(data.y_onehot, data.tau_i, (self.batch_size, self.tau_types))
                 if convert_torch_to_tf:
                     yield converter((tuple(x),y))
                 else:  

--- a/Training/python/DataLoaderBase.py
+++ b/Training/python/DataLoaderBase.py
@@ -189,7 +189,7 @@ class GetData():
             _X.append(
                 torch.cat(
                     [ __class__.getdata(_obj_grid[ getattr(R.CellObjectType,fname) ][_inner], _filled_tau,
-                     (batch_size, _n_cells, _n_cells, n_grid_features[fname])) for fname in group ],
+                     (batch_size, _n_cells, _n_cells, n_grid_features[fname]), debug_area=fname+"_in_getgrid") for fname in group ],
                     dim=-1
                     )
                 )
@@ -203,7 +203,7 @@ class GetData():
                     _n_seq,
                     _n_features):
         return [ __class__.getdata(_obj_grid[getattr(R.CellObjectType,group)], _filled_tau,
-                (_n_tau, _n_seq[group], _n_features[group]))
+                (_n_tau, _n_seq[group], _n_features[group]), debug_area=group+"_in_getsequence")
                 for group in _input_grids]
 
     @staticmethod
@@ -220,7 +220,7 @@ class GetData():
         X_all = []      
         # Flat Tau features
         if 'TauFlat' in active_features:
-            X_all += [ __class__.getdata(data.x_tau, filled_tau, (batch_size, n_flat_features)) ]
+            X_all += [ __class__.getdata(data.x_tau, filled_tau, (batch_size, n_flat_features), debug_area="TauFlat") ]
         # Inner grid
         if 'inner' in cell_locations:
             X_all += __class__.getgrid(data.x_grid, filled_tau, batch_size, n_grid_features,

--- a/Training/python/DataLoaderBase.py
+++ b/Training/python/DataLoaderBase.py
@@ -144,7 +144,7 @@ class GetData():
         for group in input_grids:
             _X.append(
                 torch.cat(
-                    [ __class__.getdata(_obj_grid[ getattr(R.CellObjectType,fname) ][_inner],
+                    [ __class__.getdata(_obj_grid[ getattr(R.CellObjectType,fname) ][_inner], _filled_tau,
                      (batch_size, _n_cells, _n_cells, n_grid_features[fname]), debug_area=fname+"_in_getgrid") for fname in group ],
                     dim=-1
                     )
@@ -157,7 +157,7 @@ class GetData():
                     _input_grids,
                     _n_seq,
                     _n_features):
-        return [ __class__.getdata(_obj_grid[getattr(R.CellObjectType,group)],
+        return [ __class__.getdata(_obj_grid[getattr(R.CellObjectType,group)], _filled_tau,
                 (_n_tau, _n_seq[group], _n_features[group]), debug_area=group+"_in_getsequence")
                 for group in _input_grids]
 
@@ -174,7 +174,7 @@ class GetData():
         X_all = []      
         # Flat Tau features
         if 'TauFlat' in active_features:
-            X_all += [ __class__.getdata(data.x_tau, (batch_size, n_flat_features), debug_area="TauFlat") ]
+            X_all += [ __class__.getdata(data.x_tau, filled_tau, (batch_size, n_flat_features), debug_area="TauFlat") ]
         # Inner grid
         if 'inner' in cell_locations:
             X_all += __class__.getgrid(data.x_grid, batch_size, n_grid_features,

--- a/Training/python/config_parse.py
+++ b/Training/python/config_parse.py
@@ -30,7 +30,7 @@ def create_settings(data: dict, verbose=False) -> str:
     def create_namestruc(content: dict) -> str:
         types_map = {
                 bool  : "Bool_t",
-                int   : "size_t",
+                int   : "long int",
                 float : "Double_t",
                 str   : "std::string",
                 list  : "std::vector<std::string>",


### PR DESCRIPTION
- Introduced the possibility of reading data from previously saved tf datasets for training
- Added a script ROOT_to_tf to save ROOT files as a tf dataset
Minor fixes:
- Conversion from torch to tf in get_predict_generator fro apply training
- Change size-t -> long int in C++ parser to avoid problem observed when DeepTauVSjet cut set to -1
- Fixed small problem for file names with dashes for evaluation
- Made histo2d get weights shared pointer in definition
- Fix bug in regularisation implementation for convolutional layers
- Improved error messages when NaN found in tensor

