### PR TITLE
Custom Training Loop

### DIFF
--- a/Training/python/2018v1/Training_v0p1.py
+++ b/Training/python/2018v1/Training_v0p1.py
@@ -368,7 +368,7 @@ def create_model(net_config, model_name):
                          kernel_initializer=dense_net_setup.kernel_init)(final_dense)
     softmax_output = Activation("softmax", name="main_output")(output_layer)
 
-    model = Model(input_layers, softmax_output, name=model_name)
+    model = DeepTauModel(input_layers, softmax_output, name=model_name)
     return model
 
 def compile_model(model, opt_name, learning_rate):
@@ -385,7 +385,7 @@ def compile_model(model, opt_name, learning_rate):
         TauLosses.Hcat_eInv, TauLosses.Hcat_muInv, TauLosses.Hcat_jetInv,
         TauLosses.Fe, TauLosses.Fmu, TauLosses.Fjet, TauLosses.Fcmb
     ]
-    model.compile(loss=TauLosses.tau_crossentropy_v2, optimizer=opt, metrics=metrics, weighted_metrics=metrics)
+    model.compile(loss=None, optimizer=opt, metrics=metrics, weighted_metrics=metrics) # loss is now defined in DeepTauModel
 
     # log metric names for passing them during model loading
     metric_names = {(m if isinstance(m, str) else m.__name__): '' for m in metrics}

--- a/Training/python/2018v1/Training_v0p1.py
+++ b/Training/python/2018v1/Training_v0p1.py
@@ -32,18 +32,12 @@ from common import *
 import DataLoader
 
 class DeepTauModel(keras.Model):
-    _loss_tracker = keras.metrics.Mean(name="loss")
-    _pure_loss_tracker = keras.metrics.Mean(name="pure_loss")
-    _reg_loss_tracker = keras.metrics.Mean(name ="reg_loss")
 
-    def loss_tracker(self): # tracker to compute the weighted total loss
-        return type(self)._loss_tracker
-
-    def pure_loss_tracker(self):
-        return type(self)._pure_loss_tracker
-
-    def reg_loss_tracker(self):
-        return type(self)._reg_loss_tracker
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.loss_tracker = keras.metrics.Mean(name="loss")
+        self.pure_loss_tracker = keras.metrics.Mean(name="pure_loss")
+        self.reg_loss_tracker = keras.metrics.Mean(name ="reg_loss")
 
     def train_step(self, data):
         # Unpack the data
@@ -70,9 +64,9 @@ class DeepTauModel(keras.Model):
         # Update weights
         self.optimizer.apply_gradients(zip(gradients, trainable_vars))
         # Update metrics (including the ones that track losses)
-        self.loss_tracker().update_state(loss, sample_weight=sample_weight)
-        self.pure_loss_tracker().update_state(pure_loss, sample_weight=sample_weight) 
-        self.reg_loss_tracker().update_state(reg_loss)
+        self.loss_tracker.update_state(loss, sample_weight=sample_weight)
+        self.pure_loss_tracker.update_state(pure_loss, sample_weight=sample_weight) 
+        self.reg_loss_tracker.update_state(reg_loss)
         self.compiled_metrics.update_state(y, y_pred, sample_weight)
         # Return a dict mapping metric names to current value (printout)
         metrics_out =  {m.name: m.result() for m in self.metrics}
@@ -99,9 +93,9 @@ class DeepTauModel(keras.Model):
             reg_loss = reg_losses # empty
             loss = pure_loss
         # Update the metrics (including the ones that track losses)
-        self.loss_tracker().update_state(loss, sample_weight=sample_weight)
-        self.pure_loss_tracker().update_state(pure_loss, sample_weight=sample_weight) 
-        self.reg_loss_tracker().update_state(reg_loss)
+        self.loss_tracker.update_state(loss, sample_weight=sample_weight)
+        self.pure_loss_tracker.update_state(pure_loss, sample_weight=sample_weight) 
+        self.reg_loss_tracker.update_state(reg_loss)
         self.compiled_metrics.update_state(y, y_pred, sample_weight)
         # Return a dict mapping metric names to current value
         metrics_out = {m.name: m.result() for m in self.metrics}
@@ -113,9 +107,9 @@ class DeepTauModel(keras.Model):
         # called automatically at the start of each epoch
         # or at the start of `evaluate()`
         metrics = []
-        metrics.append(self.loss_tracker()) 
-        metrics.append(self.reg_loss_tracker())
-        metrics.append(self.pure_loss_tracker())
+        metrics.append(self.loss_tracker) 
+        metrics.append(self.reg_loss_tracker)
+        metrics.append(self.pure_loss_tracker)
         if self._is_compiled:
             #  Track `LossesContainer` and `MetricsContainer` objects
             # so that attr names are not load-bearing.


### PR DESCRIPTION
-> Defined a DeepTauModel class that inherits from Model to implement custom training
-> Implemented a correct loss function
-> Added metrics that track regularisation loss and pure loss (loss - regularisation loss)

We discovered a couple of weeks ago that the loss that's compiled in tensorflow Model.fit() is not computed correctly, our loss function is taucrossentropy_v2 and should therefore match the weighted_taucrossentropy_v2 metric but this was not the case. This is caused by tensorflow not dividing the loss by the sum of the weights.
We are therefore moving towards a custom training loop, tensorflow allows us to override methods such as train_step, test_step and metrics by defining a class that inherits from tf.Model. This means we still have access to callbacks and tracking but can define a correct loss function and have more customisation options.