### PR TITLE
Recompute tau type script

### DIFF
--- a/Analysis/interface/TauSelection.h
+++ b/Analysis/interface/TauSelection.h
@@ -6,48 +6,50 @@
 #include "TauMLTools/Core/interface/exception.h"
 
 namespace analysis {
-    boost::optional<GenLeptonMatch> GetGenLeptonMatch(const tau_tuple::Tau& tau)
+    boost::optional<GenLeptonMatch> GetGenLeptonMatch(Int_t tau_genLepton_kind,  Int_t genLepton_index,  Float_t tau_pt,  Float_t tau_eta,
+     Float_t tau_phi,  Float_t tau_mass,  Float_t genLepton_vis_pt,  Float_t genLepton_vis_eta,  Float_t genLepton_vis_phi,  Float_t genLepton_vis_mass,
+     Int_t genJet_index)
     {   
         using GTGenLeptonKind = reco_tau::gen_truth::GenLepton::Kind;
-        const GTGenLeptonKind genLepton_kind = static_cast<GTGenLeptonKind> (tau.genLepton_kind);
+        const GTGenLeptonKind genLepton_kind = static_cast<GTGenLeptonKind> (tau_genLepton_kind);
 
-        if (tau.genLepton_index >= 0){
-            LorentzVectorM genv(tau.tau_pt, tau.tau_eta, tau.tau_phi, tau.tau_mass);
-            LorentzVectorM tauv(  tau.genLepton_vis_pt  ,
-                                tau.genLepton_vis_eta ,
-                                tau.genLepton_vis_phi ,
-                                tau.genLepton_vis_mass);
+        if (genLepton_index >= 0){
+            LorentzVectorM genv(tau_pt, tau_eta, tau_phi, tau_mass);
+            LorentzVectorM tauv(  genLepton_vis_pt  ,
+                                genLepton_vis_eta ,
+                                genLepton_vis_phi ,
+                                genLepton_vis_mass);
 
             if (ROOT::Math::VectorUtil::DeltaR(tauv, genv) > 0.2){
                 return boost::none;
             }
 
             if (genLepton_kind == GTGenLeptonKind::PromptElectron){
-                if (tau.genLepton_vis_pt < 8.0) return boost::none;
+                if (genLepton_vis_pt < 8.0) return boost::none;
                 return GenLeptonMatch::Electron;
             }
             else if (genLepton_kind == GTGenLeptonKind::PromptMuon){
-                if (tau.genLepton_vis_pt < 8.0) return boost::none;
+                if (genLepton_vis_pt < 8.0) return boost::none;
                 return GenLeptonMatch::Muon;
             }
             else if (genLepton_kind == GTGenLeptonKind::TauDecayedToElectron){
-                if (tau.genLepton_vis_pt < 8.0) return boost::none;
+                if (genLepton_vis_pt < 8.0) return boost::none;
                 return GenLeptonMatch::TauElectron;
             }
             else if (genLepton_kind == GTGenLeptonKind::TauDecayedToMuon){
-                if (tau.genLepton_vis_pt < 8.0) return boost::none;
+                if (genLepton_vis_pt < 8.0) return boost::none;
                 return GenLeptonMatch::TauMuon;
             }
             else if (genLepton_kind == GTGenLeptonKind::TauDecayedToHadrons){
-                if (tau.genLepton_vis_pt < 15.0) return boost::none;
+                if (genLepton_vis_pt < 15.0) return boost::none;
                 return GenLeptonMatch::Tau;
             }
             else {
                 throw exception("genLepton_kind = %1% should not happend when genLepton_index is %2%")
-                    %tau.genLepton_kind %tau.genLepton_index;
+                    %tau_genLepton_kind %genLepton_index;
             }
         }
-        else if (tau.genJet_index >= 0){
+        else if (genJet_index >= 0){
             return GenLeptonMatch::NoMatch;
         }
         else {

--- a/Analysis/interface/TauSelection.h
+++ b/Analysis/interface/TauSelection.h
@@ -6,7 +6,7 @@
 #include "TauMLTools/Core/interface/exception.h"
 
 namespace analysis {
-    boost::optional<GenLeptonMatch> GetGenLeptonMatch(Int_t tau_genLepton_kind,  Int_t genLepton_index,  Float_t tau_pt,  Float_t tau_eta,
+    std::optional<GenLeptonMatch> GetGenLeptonMatch(Int_t tau_genLepton_kind,  Int_t genLepton_index,  Float_t tau_pt,  Float_t tau_eta,
      Float_t tau_phi,  Float_t tau_mass,  Float_t genLepton_vis_pt,  Float_t genLepton_vis_eta,  Float_t genLepton_vis_phi,  Float_t genLepton_vis_mass,
      Int_t genJet_index)
     {   
@@ -21,27 +21,27 @@ namespace analysis {
                                 genLepton_vis_mass);
 
             if (ROOT::Math::VectorUtil::DeltaR(tauv, genv) > 0.2){
-                return boost::none;
+                return std::nullopt;
             }
 
             if (genLepton_kind == GTGenLeptonKind::PromptElectron){
-                if (genLepton_vis_pt < 8.0) return boost::none;
+                if (genLepton_vis_pt < 8.0) return std::nullopt;
                 return GenLeptonMatch::Electron;
             }
             else if (genLepton_kind == GTGenLeptonKind::PromptMuon){
-                if (genLepton_vis_pt < 8.0) return boost::none;
+                if (genLepton_vis_pt < 8.0) return std::nullopt;
                 return GenLeptonMatch::Muon;
             }
             else if (genLepton_kind == GTGenLeptonKind::TauDecayedToElectron){
-                if (genLepton_vis_pt < 8.0) return boost::none;
+                if (genLepton_vis_pt < 8.0) return std::nullopt;
                 return GenLeptonMatch::TauElectron;
             }
             else if (genLepton_kind == GTGenLeptonKind::TauDecayedToMuon){
-                if (genLepton_vis_pt < 8.0) return boost::none;
+                if (genLepton_vis_pt < 8.0) return std::nullopt;
                 return GenLeptonMatch::TauMuon;
             }
             else if (genLepton_kind == GTGenLeptonKind::TauDecayedToHadrons){
-                if (genLepton_vis_pt < 15.0) return boost::none;
+                if (genLepton_vis_pt < 15.0) return std::nullopt;
                 return GenLeptonMatch::Tau;
             }
             else {
@@ -53,7 +53,7 @@ namespace analysis {
             return GenLeptonMatch::NoMatch;
         }
         else {
-            return boost::none;
+            return std::nullopt;
         }
     }
 } // namespace analysis

--- a/Analysis/python/recompute_tautype.py
+++ b/Analysis/python/recompute_tautype.py
@@ -1,5 +1,6 @@
 import ROOT as R
 import os
+import numpy as npd
 
 _rootpath = os.path.abspath(os.path.dirname(__file__)+"../../..")
 R.gROOT.ProcessLine(".include "+_rootpath)
@@ -13,10 +14,27 @@ R.gInterpreter.ProcessLine('''
 
 ''')
 
+df = R.RDataFrame("taus", "~/histograms/eventTuple_15.root")
+
+#print(df.GetColumnNames())
 def compute(df):
-    df = df.Define("mytauType", """analysis::GenMatchToTauType(*analysis::GetGenLeptonMatch(genLepton_kind, genLepton_index, tau_pt, tau_eta, tau_phi, tau_mass,
-        genLepton_vis_pt, genLepton_vis_eta, genLepton_vis_phi, genLepton_vis_mass, genJet_index), analysis::SampleType(sampleType))""")
+    df = df.Define("gen_match", """analysis::GetGenLeptonMatch(genLepton_kind, genLepton_index, tau_pt, tau_eta, tau_phi, tau_mass, 
+    genLepton_vis_pt, genLepton_vis_eta, genLepton_vis_phi, genLepton_vis_mass, genJet_index)""")
+    df = df.Define("sample_type", """static_cast<analysis::SampleType>(sampleType)""")
+    df = df.Define("mytauType", "static_cast<int>(analysis::GenMatchToTauType(*gen_match, sample_type))")
     print("Tau Types Recomputed")
     return df
 
+df = compute(df)
+print(df.GetColumnNames())
+test = df.AsNumpy(columns=["tauType"])
+npdf = df.AsNumpy(columns=["gen_match"])
+npdf2 = df.AsNumpy(columns=["sample_type"])
+npdf3 = df.AsNumpy(columns=["mytauType"])
+print(npdf)
+print(npdf2)
+print(test)
+print(npdf3)
 
+    # df = df.Define("mytauType", """static_cast<Int_t>(analysis::GenMatchToTauType(*analysis::GetGenLeptonMatch(genLepton_kind, genLepton_index, tau_pt, tau_eta, tau_phi, tau_mass,
+    #     genLepton_vis_pt, genLepton_vis_eta, genLepton_vis_phi, genLepton_vis_mass, genJet_index), static_cast<analysis::SampleType>(sampleType)))""")

--- a/Analysis/python/recompute_tautype.py
+++ b/Analysis/python/recompute_tautype.py
@@ -5,9 +5,6 @@ _rootpath = os.path.abspath(os.path.dirname(__file__)+"../../../..")
 R.gROOT.ProcessLine(".include "+_rootpath)
 R.gInterpreter.ProcessLine('''
 
-#include "TauMLTools/Analysis/interface/TauTuple.h"
-#include "TROOT.h"
-#include "TLorentzVector.h"
 #include "TauMLTools/Analysis/interface/TauSelection.h"
 #include "TauMLTools/Analysis/interface/AnalysisTypes.h"
 

--- a/Analysis/python/recompute_tautype.py
+++ b/Analysis/python/recompute_tautype.py
@@ -1,0 +1,22 @@
+import ROOT as R
+import os
+
+_rootpath = os.path.abspath(os.path.dirname(__file__)+"../../..")
+R.gROOT.ProcessLine(".include "+_rootpath)
+R.gInterpreter.ProcessLine('''
+
+#include "TauMLTools/Analysis/interface/TauTuple.h"
+#include "TROOT.h"
+#include "TLorentzVector.h"
+#include "TauMLTools/Analysis/interface/TauSelection.h"
+#include "TauMLTools/Analysis/interface/AnalysisTypes.h"
+
+''')
+
+def redefine(df):
+    df = df.Define("mytauType", """analysis::GenMatchToTauType(*analysis::GetGenLeptonMatch(genLepton_kind, genLepton_index, tau_pt, tau_eta, tau_phi, tau_mass,
+        genLepton_vis_pt, genLepton_vis_eta, genLepton_vis_phi, genLepton_vis_mass, genJet_index), analysis::SampleType(sampleType))""")
+    print("Tau Types Recomputed")
+    return df
+
+

--- a/Analysis/python/recompute_tautype.py
+++ b/Analysis/python/recompute_tautype.py
@@ -34,6 +34,7 @@ int GetMyTauType(Int_t tau_genLepton_kind,  Int_t genLepton_index,  Float_t tau_
 ''')
 
 def compute(df):
+    # currently define a new branch in the dataframe while we wait for ROOT v6.26 where we can use Redefine("tauType")
     df = df.Define("mytauType", """GetMyTauType(genLepton_kind, genLepton_index, tau_pt, tau_eta, tau_phi, tau_mass, 
                         genLepton_vis_pt, genLepton_vis_eta, genLepton_vis_phi, genLepton_vis_mass, genJet_index, sampleType)""")
     print("Tau Types Recomputed")

--- a/Analysis/python/recompute_tautype.py
+++ b/Analysis/python/recompute_tautype.py
@@ -13,7 +13,7 @@ R.gInterpreter.ProcessLine('''
 
 ''')
 
-def redefine(df):
+def compute(df):
     df = df.Define("mytauType", """analysis::GenMatchToTauType(*analysis::GetGenLeptonMatch(genLepton_kind, genLepton_index, tau_pt, tau_eta, tau_phi, tau_mass,
         genLepton_vis_pt, genLepton_vis_eta, genLepton_vis_phi, genLepton_vis_mass, genJet_index), analysis::SampleType(sampleType))""")
     print("Tau Types Recomputed")

--- a/Analysis/python/recompute_tautype.py
+++ b/Analysis/python/recompute_tautype.py
@@ -12,29 +12,30 @@ R.gInterpreter.ProcessLine('''
 #include "TauMLTools/Analysis/interface/TauSelection.h"
 #include "TauMLTools/Analysis/interface/AnalysisTypes.h"
 
+int GetMyTauType(Int_t tau_genLepton_kind,  Int_t genLepton_index,  Float_t tau_pt,  Float_t tau_eta,
+     Float_t tau_phi,  Float_t tau_mass,  Float_t genLepton_vis_pt,  Float_t genLepton_vis_eta,  Float_t genLepton_vis_phi,  
+     Float_t genLepton_vis_mass, Int_t genJet_index, Int_t sampleType)
+     {
+        const auto gen_match = analysis::GetGenLeptonMatch(tau_genLepton_kind, genLepton_index, tau_pt, tau_eta, tau_phi, tau_mass, 
+                                                            genLepton_vis_pt, genLepton_vis_eta, genLepton_vis_phi, 
+                                                            genLepton_vis_mass, genJet_index);
+        const auto sample_type= static_cast<analysis::SampleType> (sampleType);
+        int mytauType;
+        if (gen_match){
+            mytauType = static_cast<int>(analysis::GenMatchToTauType(*gen_match, sample_type));
+            return mytauType;
+        }
+        else{
+            mytauType = -1;
+            return mytauType;
+        }   
+}
+
 ''')
 
-df = R.RDataFrame("taus", "~/histograms/eventTuple_15.root")
-
-#print(df.GetColumnNames())
 def compute(df):
-    df = df.Define("gen_match", """analysis::GetGenLeptonMatch(genLepton_kind, genLepton_index, tau_pt, tau_eta, tau_phi, tau_mass, 
-    genLepton_vis_pt, genLepton_vis_eta, genLepton_vis_phi, genLepton_vis_mass, genJet_index)""")
-    df = df.Define("sample_type", """static_cast<analysis::SampleType>(sampleType)""")
-    df = df.Define("mytauType", "static_cast<int>(analysis::GenMatchToTauType(*gen_match, sample_type))")
+    df = df.Define("mytauType", """GetMyTauType(genLepton_kind, genLepton_index, tau_pt, tau_eta, tau_phi, tau_mass, 
+                        genLepton_vis_pt, genLepton_vis_eta, genLepton_vis_phi, genLepton_vis_mass, genJet_index, sampleType)""")
     print("Tau Types Recomputed")
     return df
 
-df = compute(df)
-print(df.GetColumnNames())
-test = df.AsNumpy(columns=["tauType"])
-npdf = df.AsNumpy(columns=["gen_match"])
-npdf2 = df.AsNumpy(columns=["sample_type"])
-npdf3 = df.AsNumpy(columns=["mytauType"])
-print(npdf)
-print(npdf2)
-print(test)
-print(npdf3)
-
-    # df = df.Define("mytauType", """static_cast<Int_t>(analysis::GenMatchToTauType(*analysis::GetGenLeptonMatch(genLepton_kind, genLepton_index, tau_pt, tau_eta, tau_phi, tau_mass,
-    #     genLepton_vis_pt, genLepton_vis_eta, genLepton_vis_phi, genLepton_vis_mass, genJet_index), static_cast<analysis::SampleType>(sampleType)))""")

--- a/Core/interface/EnumNameMap.h
+++ b/Core/interface/EnumNameMap.h
@@ -74,7 +74,7 @@ public:
     const std::string& EnumToString(const Enum& e) const
     {
         if(!HasEnum(e))
-            throw exception("The corresponding string is not found for an element of the enum '%1%'.") % enum_name;
+            throw exception("The corresponding string is not found for an element = %1% of the enum '%2%'.") % static_cast<int>(e) % enum_name;
         return enum_to_string_map.at(e);
     }
 

--- a/Training/interface/DataLoader_main.h
+++ b/Training/interface/DataLoader_main.h
@@ -243,7 +243,9 @@ public:
           tauTuple->GetEntry(current_entry);
           auto& tau = const_cast<tau_tuple::Tau&>(tauTuple->data());
 
-          const auto gen_match = analysis::GetGenLeptonMatch(tau);
+          const auto gen_match = analysis::GetGenLeptonMatch(tau.genLepton_kind, tau.genLepton_index, tau.tau_pt, tau.tau_eta, tau.tau_phi,
+                                                            tau.tau_mass, tau.genLepton_vis_pt, tau.genLepton_vis_eta, tau.genLepton_vis_phi, 
+                                                            tau.genLepton_vis_mass, tau.genJet_index);
           const auto sample_type = static_cast<analysis::SampleType>(tau.sampleType);
 
           if (gen_match &&tau.tau_byDeepTau2017v2p1VSjetraw >DeepTauVSjet_cut){

--- a/Training/python/2018v1/Training_v0p1.py
+++ b/Training/python/2018v1/Training_v0p1.py
@@ -32,18 +32,12 @@ from common import *
 import DataLoader
 
 class DeepTauModel(keras.Model):
-    _loss_tracker = keras.metrics.Mean(name="loss")
-    _pure_loss_tracker = keras.metrics.Mean(name="pure_loss")
-    _reg_loss_tracker = keras.metrics.Mean(name ="reg_loss")
 
-    def loss_tracker(self): # tracker to compute the weighted total loss
-        return type(self)._loss_tracker
-
-    def pure_loss_tracker(self):
-        return type(self)._pure_loss_tracker
-
-    def reg_loss_tracker(self):
-        return type(self)._reg_loss_tracker
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.loss_tracker = keras.metrics.Mean(name="loss")
+        self.pure_loss_tracker = keras.metrics.Mean(name="pure_loss")
+        self.reg_loss_tracker = keras.metrics.Mean(name ="reg_loss")
 
     def train_step(self, data):
         # Unpack the data
@@ -70,9 +64,9 @@ class DeepTauModel(keras.Model):
         # Update weights
         self.optimizer.apply_gradients(zip(gradients, trainable_vars))
         # Update metrics (including the ones that track losses)
-        self.loss_tracker().update_state(loss, sample_weight=sample_weight)
-        self.pure_loss_tracker().update_state(pure_loss, sample_weight=sample_weight) 
-        self.reg_loss_tracker().update_state(reg_loss)
+        self.loss_tracker.update_state(loss, sample_weight=sample_weight)
+        self.pure_loss_tracker.update_state(pure_loss, sample_weight=sample_weight) 
+        self.reg_loss_tracker.update_state(reg_loss)
         self.compiled_metrics.update_state(y, y_pred, sample_weight)
         # Return a dict mapping metric names to current value (printout)
         metrics_out =  {m.name: m.result() for m in self.metrics}
@@ -99,9 +93,9 @@ class DeepTauModel(keras.Model):
             reg_loss = reg_losses # empty
             loss = pure_loss
         # Update the metrics (including the ones that track losses)
-        self.loss_tracker().update_state(loss, sample_weight=sample_weight)
-        self.pure_loss_tracker().update_state(pure_loss, sample_weight=sample_weight) 
-        self.reg_loss_tracker().update_state(reg_loss)
+        self.loss_tracker.update_state(loss, sample_weight=sample_weight)
+        self.pure_loss_tracker.update_state(pure_loss, sample_weight=sample_weight) 
+        self.reg_loss_tracker.update_state(reg_loss)
         self.compiled_metrics.update_state(y, y_pred, sample_weight)
         # Return a dict mapping metric names to current value
         metrics_out = {m.name: m.result() for m in self.metrics}
@@ -113,9 +107,9 @@ class DeepTauModel(keras.Model):
         # called automatically at the start of each epoch
         # or at the start of `evaluate()`
         metrics = []
-        metrics.append(self.loss_tracker()) 
-        metrics.append(self.reg_loss_tracker())
-        metrics.append(self.pure_loss_tracker())
+        metrics.append(self.loss_tracker) 
+        metrics.append(self.reg_loss_tracker)
+        metrics.append(self.pure_loss_tracker)
         if self._is_compiled:
             #  Track `LossesContainer` and `MetricsContainer` objects
             # so that attr names are not load-bearing.


### PR DESCRIPTION
Introduced a script to recompute tau type, function takes a ROOT Dataframe as input and returns a Dataframe with a newly computed tauType.
Changes made:
- Added recompute_tautype script
- Analysis/Interface/TauSelection.h GetGenLeptonMatch now takes individual branches as inputs instead of tau tuple (more flexible)
- DataLoader.h GetGenLeptonMatch call changed for new argument format
