### PR TITLE
Few eval changes proposal

### DIFF
--- a/Evaluation/apply_training.py
+++ b/Evaluation/apply_training.py
@@ -2,6 +2,7 @@ import os
 import sys
 import json
 import git
+import glob
 from tqdm import tqdm
 
 import uproot
@@ -58,67 +59,79 @@ def main(cfg: DictConfig) -> None:
     dataloader = DataLoader.DataLoader(training_cfg, scaling_cfg)
     gen_predict = dataloader.get_predict_generator()
     tau_types_names = training_cfg['Setup']['tau_types_names']
-       
-    # open input file
-    input_file_name = to_absolute_path(f'{cfg.path_to_input_dir}/{cfg.input_filename}.root')
-    with uproot.open(input_file_name) as f:
-        t = f['taus']
-        n_taus = len(t['evt'].array())
-    
-    # run predictions
-    predictions = []
-    targets = []
-    if cfg.verbose: print(f'\n\n--> Processing file {input_file_name}, number of taus: {n_taus}\n')
 
-    with tqdm(total=n_taus) as pbar:
+    pathes = glob.glob(to_absolute_path(cfg.path_to_input_dir)+'/*root') if cfg.input_filename is None \
+             else [to_absolute_path(f'{cfg.path_to_input_dir}/{cfg.input_filename}.root')]
 
-        for (X,y),indexes,size in gen_predict(input_file_name):
+    for input_file_name in pathes:
 
-            y_pred = np.zeros((size, y.shape[1]))
-            y_target = np.zeros((size, y.shape[1]))
+        # output filename definition:
+        output_filename = os.path.splitext(os.path.basename(input_file_name))[0]+"_pred"  if cfg.input_filename is None \
+                          else cfg.output_filename
+        if os.path.exists(f'{path_to_artifacts}/predictions/{cfg.sample_alias}/{output_filename}.h5'):
+            print("File exists: ", f'{path_to_artifacts}/predictions/{cfg.sample_alias}/{output_filename}.h5')
+            continue
 
-            y_pred[indexes] = model.predict(X)
-            y_target[indexes] = y
+        # open input file
+        with uproot.open(input_file_name) as f:
+            t = f['taus']
+            n_taus = len(t['evt'].array())
 
-            predictions.append(y_pred)
-            targets.append(y_target)
+        # run predictions
+        predictions = []
+        targets = []
+        if cfg.verbose: print(f'\n\n--> Processing file {input_file_name}, number of taus: {n_taus}\n')
 
-            pbar.update(size)
+        with tqdm(total=n_taus) as pbar:
 
-    # concat and check for validity
-    predictions = np.concatenate(predictions, axis=0)
-    targets = np.concatenate(targets, axis=0)
+            for (X,y),indexes,size in gen_predict(input_file_name):
 
-    if np.any(np.isnan(predictions)):
-        raise RuntimeError("NaN in predictions. Total count = {} out of {}".format(
-                            np.count_nonzero(np.isnan(predictions)), predictions.shape))
-    if np.any(predictions < 0) or np.any(predictions > 1):
-        raise RuntimeError("Predictions outside [0, 1] range.")
+                y_pred = np.zeros((size, y.shape[1]))
+                y_target = np.zeros((size, y.shape[1]))
 
-    # store into intermediate hdf5 file
-    predictions = pd.DataFrame({f'node_{tau_type}': predictions[:, int(idx)] for idx, tau_type in tau_types_names.items()})
-    targets = pd.DataFrame({f'node_{tau_type}': targets[:, int(idx)] for idx, tau_type in tau_types_names.items()}, dtype=np.int64)
-    predictions.to_hdf(f'{cfg.output_filename}.h5', key='predictions', mode='w', format='fixed', complevel=1, complib='zlib')
-    targets.to_hdf(f'{cfg.output_filename}.h5', key='targets', mode='r+', format='fixed', complevel=1, complib='zlib')
-    
-    # log to mlflow and delete intermediate file
-    with mlflow.start_run(experiment_id=cfg.experiment_id, run_id=cfg.run_id) as active_run:
-        mlflow.log_artifact(f'{cfg.output_filename}.h5', f'predictions/{cfg.sample_alias}')
-    os.remove(f'{cfg.output_filename}.h5')
+                y_pred[indexes] = model.predict(X)
+                y_target[indexes] = y
 
-    # log mapping between prediction file and corresponding input file 
-    json_filemap_name = f'{path_to_artifacts}/predictions/{cfg.sample_alias}/pred_input_filemap.json'
-    json_filemap_exists = os.path.exists(json_filemap_name)
-    json_open_mode = 'r+' if json_filemap_exists else 'w'
-    with open(json_filemap_name, json_open_mode) as json_file:
-        if json_filemap_exists: # read performance data to append additional info 
-            filemap_data = json.load(json_file)
-        else: # create dictionary to fill with data
-            filemap_data = {}
-        filemap_data[os.path.abspath(f'{path_to_artifacts}/predictions/{cfg.sample_alias}/{cfg.output_filename}.h5')] = input_file_name
-        json_file.seek(0) 
-        json_file.write(json.dumps(filemap_data, indent=4))
-        json_file.truncate()
+                predictions.append(y_pred)
+                targets.append(y_target)
+
+                pbar.update(size)
+
+        # concat and check for validity
+        predictions = np.concatenate(predictions, axis=0)
+        targets = np.concatenate(targets, axis=0)
+
+        if np.any(np.isnan(predictions)):
+            raise RuntimeError("NaN in predictions. Total count = {} out of {}".format(
+                                np.count_nonzero(np.isnan(predictions)), predictions.shape))
+        if np.any(predictions < 0) or np.any(predictions > 1):
+            raise RuntimeError("Predictions outside [0, 1] range.")
+
+
+        # store into intermediate hdf5 file
+        predictions = pd.DataFrame({f'node_{tau_type}': predictions[:, int(idx)] for idx, tau_type in tau_types_names.items()})
+        targets = pd.DataFrame({f'node_{tau_type}': targets[:, int(idx)] for idx, tau_type in tau_types_names.items()}, dtype=np.int64)
+        predictions.to_hdf(f'{output_filename}.h5', key='predictions', mode='w', format='fixed', complevel=1, complib='zlib')
+        targets.to_hdf(f'{output_filename}.h5', key='targets', mode='r+', format='fixed', complevel=1, complib='zlib')
+
+        # log to mlflow and delete intermediate file
+        with mlflow.start_run(experiment_id=cfg.experiment_id, run_id=cfg.run_id) as active_run:
+            mlflow.log_artifact(f'{output_filename}.h5', f'predictions/{cfg.sample_alias}')
+        os.remove(f'{output_filename}.h5')
+
+        # log mapping between prediction file and corresponding input file
+        json_filemap_name = f'{path_to_artifacts}/predictions/{cfg.sample_alias}/pred_input_filemap.json'
+        json_filemap_exists = os.path.exists(json_filemap_name)
+        json_open_mode = 'r+' if json_filemap_exists else 'w'
+        with open(json_filemap_name, json_open_mode) as json_file:
+            if json_filemap_exists: # read performance data to append additional info
+                filemap_data = json.load(json_file)
+            else: # create dictionary to fill with data
+                filemap_data = {}
+            filemap_data[os.path.abspath(f'{path_to_artifacts}/predictions/{cfg.sample_alias}/{output_filename}.h5')] = input_file_name
+            json_file.seek(0)
+            json_file.write(json.dumps(filemap_data, indent=4))
+            json_file.truncate()
 
 if __name__ == '__main__':
     repo = git.Repo(to_absolute_path('.'), search_parent_directories=True)

--- a/Evaluation/apply_training.py
+++ b/Evaluation/apply_training.py
@@ -74,8 +74,7 @@ def main(cfg: DictConfig) -> None:
 
         # open input file
         with uproot.open(input_file_name) as f:
-            t = f['taus']
-            n_taus = len(t['evt'].array())
+            n_taus = f['taus'].numentries
 
         # run predictions
         predictions = []

--- a/Evaluation/apply_training.yaml
+++ b/Evaluation/apply_training.yaml
@@ -35,4 +35,4 @@ gpu_cfg: # for running on CPU specify "gpu_cfg: null"
 
 # misc.
 verbose: True
-checkout_train_repo: True # whether to checkout git commit used for running the training (fetched from artifacts)
+checkout_train_repo: False # whether to checkout git commit used for running the training (fetched from artifacts)

--- a/Evaluation/apply_training.yaml
+++ b/Evaluation/apply_training.yaml
@@ -18,11 +18,11 @@ run_id: ???
 
 # training/scaling cfg to init DataLoader class
 path_to_training_cfg: ${path_to_mlflow}/${experiment_id}/${run_id}/artifacts/input_cfg/training_cfg.yaml
-scaling_cfg: ${path_to_mlflow}/${experiment_id}/${run_id}/artifacts/input_cfg/ShuffleMergeSpectral_trainingSamples-2_files_0_50.json
+scaling_cfg: ${path_to_mlflow}/${experiment_id}/${run_id}/artifacts/input_cfg/ShuffleMergeSpectral_trainingSamples-2_files_0_498.json
 
 # input path and file name
 path_to_input_dir: ???
-input_filename: ??? # without file extension
+input_filename: null # without file extension
 
 # output path and file name // will store prediction file in -> artifacts/predictions/{sample_alias}/{output_filename}.h5 
 sample_alias: ??? 

--- a/Evaluation/eval_tools.py
+++ b/Evaluation/eval_tools.py
@@ -336,13 +336,13 @@ def prepare_filelists(sample_alias, path_to_input, path_to_pred, path_to_target,
             return basename
         
     # prepare list of files with inputs
-    if path_to_input is not None:
-        path_to_input = os.path.abspath(to_absolute_path(fill_placeholders(path_to_input, {"{sample_alias}": sample_alias})))
-        input_common_suffix = find_common_suffix(glob(path_to_input))
-        input_files = sorted(glob(path_to_input), key=partial(path_splitter, common_suffix=input_common_suffix))
-    else:
-        input_files = []
-
+    # if path_to_input is not None:
+    #     path_to_input = os.path.abspath(to_absolute_path(fill_placeholders(path_to_input, {"{sample_alias}": sample_alias})))
+    #     input_common_suffix = find_common_suffix(glob(path_to_input))
+    #     input_files = sorted(glob(path_to_input), key=partial(path_splitter, common_suffix=input_common_suffix))
+    # else:
+    #     input_files = []
+    
     # prepare list of files with target labels
     if path_to_target is not None:
         path_to_target = os.path.abspath(to_absolute_path(fill_placeholders(path_to_target, {"{sample_alias}": sample_alias})))
@@ -352,24 +352,32 @@ def prepare_filelists(sample_alias, path_to_input, path_to_pred, path_to_target,
             if os.path.exists(json_filemap_name):
                 with open(json_filemap_name, 'r') as json_file:
                     target_input_map = json.load(json_file)
-                    target_common_suffix = find_common_suffix(target_input_map.keys())
-                    target_files, input_files = zip(*sorted(target_input_map.items(), key=lambda item: partial(path_splitter, common_suffix=target_common_suffix)(item[0])))  # sort by values (target files)
+                    # target_common_suffix = find_common_suffix(target_input_map.keys())
+                    # target_files, input_files = zip(*sorted(target_input_map.items(), key=lambda item: partial(path_splitter, common_suffix=target_common_suffix)(item[0])))  # sort by values (target files)
+                    target_files = glob(path_to_target)
+                    input_files = [target_input_map[file] for file in target_files]
             else:
                 raise FileNotFoundError(f'File {json_filemap_name} does not exist. Please make sure that input<->target file mapping is stored in mlflow run artifacts.')
         else: # use paths from cfg 
-            target_common_suffix = find_common_suffix(glob(path_to_target))
-            target_files = sorted(glob(path_to_target), key=partial(path_splitter, common_suffix=target_common_suffix)) 
-            if len(target_files) != len(input_files):
-                raise Exception(f'Number of input files ({len(input_files)}) not equal to number of target files with labels ({len(target_files)})')
+            raise FileNotFoundError(f'Target files are not in the mlflow run artifacts.')
+            # target_common_suffix = find_common_suffix(glob(path_to_target))
+            # target_files = sorted(glob(path_to_target), key=partial(path_splitter, common_suffix=target_common_suffix)) 
+            # if len(target_files) != len(input_files):
+            #     raise Exception(f'Number of input files ({len(input_files)}) not equal to number of target files with labels ({len(target_files)})')
     else: # will assume that target branches "gen_*" are present in input files
-        assert len(input_files)>0
-        target_files = [None]*len(input_files)
+        raise FileNotFoundError(f'Target is not provided. With last modification target is required')
+        # assert len(input_files)>0
+        # target_files = [None]*len(input_files)
 
     # prepare list of files with inputs/predictions
     if path_to_pred is not None:
         path_to_pred = os.path.abspath(to_absolute_path(fill_placeholders(path_to_pred, {"{sample_alias}": sample_alias})))
-        pred_common_suffix = find_common_suffix(glob(path_to_pred))
-        pred_files = sorted(glob(path_to_pred), key=partial(path_splitter, common_suffix=pred_common_suffix))
+        # pred_common_suffix = find_common_suffix(glob(path_to_pred))
+        # pred_files = sorted(glob(path_to_pred), key=partial(path_splitter, common_suffix=pred_common_suffix))
+        if f'artifacts/predictions/{sample_alias}' in path_to_pred and path_to_pred==path_to_target:
+            pred_files = target_files
+        else:
+            raise FileNotFoundError('path to target and prediction should be the same')   
         if len(pred_files) != len(input_files):
             raise Exception(f'Number of input files ({len(input_files)}) not equal to number of prediction files with labels ({len(pred_files)})')
     else: # will assume that predictions are present in input files

--- a/Evaluation/evaluate_performance.py
+++ b/Evaluation/evaluate_performance.py
@@ -15,7 +15,7 @@ import eval_tools
 @hydra.main(config_path='configs', config_name='run3')
 def main(cfg: DictConfig) -> None:
     mlflow.set_tracking_uri(f"file://{to_absolute_path(cfg.path_to_mlflow)}")
-    
+
     # setting paths
     # path_to_weights_taus = to_absolute_path(cfg.path_to_weights_taus) if cfg.path_to_weights_taus is not None else None
     # path_to_weights_vs_type = to_absolute_path(cfg.path_to_weights_vs_type) if cfg.path_to_weights_vs_type is not None else None
@@ -129,7 +129,8 @@ def main(cfg: DictConfig) -> None:
                     'dashed': curve.dashed,
                     'marker_size': curve.marker_size
                 }
-                curve_data['plot_setup']['ratio_title'] = 'MVA/DeepTau' if cfg.vs_type != 'mu' else 'cut based/DeepTau'
+                # curve_data['plot_setup']['ratio_title'] = 'MVA/DeepTau' if cfg.vs_type != 'mu' else 'cut based/DeepTau'
+                curve_data['plot_setup']['ratio_title'] = "ratio"
 
                 # plot setup for the curve
                 for lim_name in [ 'x', 'y', 'ratio_y' ]:

--- a/Evaluation/plot_roc.py
+++ b/Evaluation/plot_roc.py
@@ -11,7 +11,7 @@ from matplotlib.backends.backend_pdf import PdfPages
 from eval_tools import select_curve, create_roc_ratio
 
 class RocCurve:
-    def __init__(self, data, ref_roc=None, WPcurve=True):
+    def __init__(self, data, ref_roc=None, WPcurve=False):
         fpr = np.array(data['false_positive_rate'])
         n_points = len(fpr)
         self.auc_score = data.get('auc_score')
@@ -41,7 +41,11 @@ class RocCurve:
 
         if ref_roc is None:
             ref_roc = self
-        self.ratio = create_roc_ratio(self.pr[1], self.pr[0], ref_roc.pr[1], ref_roc.pr[0], WPcurve)
+
+        if WPcurve:
+            self.ratio = None
+        else:
+            self.ratio = create_roc_ratio(self.pr[1], self.pr[0], ref_roc.pr[1], ref_roc.pr[0], True)
 
     def Draw(self, ax, ax_ratio = None):
         main_plot_adjusted = False
@@ -176,7 +180,8 @@ def main(cfg: DictConfig) -> None:
                 if discr_curve is None:
                     print(f'[INFO] Didn\'t manage to retrieve a curve ({curve_type}) for discriminator ({discr_name}) from performance.json. Will proceed without plotting it.')
                     continue
-                elif (discr_name==ref_discr_name and curve_type==ref_curve_type) or ('wp' in curve_type and any('curve' in ctype for ctype in curve_types)): # Temporary: Don't make ratio for 'roc_wp' if there's a ratio for 'roc_curve' already
+                # elif (discr_name==ref_discr_name and curve_type==ref_curve_type) or ('wp' in curve_type and any('curve' in ctype for ctype in curve_types)): # Temporary: Don't make ratio for 'roc_wp' if there's a ratio for 'roc_curve' already
+                elif (discr_name==ref_discr_name and curve_type==ref_curve_type):
                     curves_to_plot.append(RocCurve(discr_curve, ref_roc=None))
                 else:
                     curves_to_plot.append(RocCurve(discr_curve, ref_roc=ref_roc, WPcurve='wp' in curve_type))


### PR DESCRIPTION
Not urgent PR, but would be nice to stabilize some aspects of evaluate performance scripts if possible, unless it is of course very local whims

Here I add / request few small changes to make life easier:
1) Not to run many times apply_training, we can loop over files in the folder.
2) If I don't apply training for all files in the folder e.g: for /eos/../DYJetsToLL_M-50-amcatnloFXFX_ext2/* I should be able to run just on the files I produced, for this in loops we need to rely only on available *.h5 files not on all *.root files.
3) Propose to disable checkout_train_repo by default because it can play a dangerous trick when stash the changes and then not pop it back if script fails.
4) There are some problems with plot_roc.py, when I put current training as a reference then I had an overlap of colors in the 1.0 line
5) To do: is it possible to define axis and ranges on the plot_roc.py level, because it hard to rerun evaluate_performance for an every cosmetic changes? (now all this dropped in performance.json on the evaluate_performance step)