### PR TITLE
Minor changes to GetGenLeptonMatch and RootExt

### DIFF
--- a/Analysis/bin/CreateSpectralHists.cxx
+++ b/Analysis/bin/CreateSpectralHists.cxx
@@ -138,7 +138,9 @@ private:
 
     void AddTau(const Tau& tau)
     {
-        const auto gen_match = GetGenLeptonMatch(tau);
+        const auto gen_match = GetGenLeptonMatch(static_cast<reco_tau::gen_truth::GenLepton::Kind>(tau.genLepton_kind), tau.genLepton_index, 
+                                                              tau.tau_pt, tau.tau_eta, tau.tau_phi, tau.tau_mass, tau.genLepton_vis_pt, 
+                                                              tau.genLepton_vis_eta, tau.genLepton_vis_phi, tau.genLepton_vis_mass, tau.genJet_index);
         if(PassSelection(tau) && gen_match) {
             const auto sample_type = static_cast<SampleType>(tau.sampleType);
             const TauType tau_type = analysis::GenMatchToTauType(*gen_match, sample_type);

--- a/Analysis/bin/ShuffleMergeSpectral.cxx
+++ b/Analysis/bin/ShuffleMergeSpectral.cxx
@@ -147,7 +147,11 @@ struct SourceDesc {
         ++total_n_processed;
 
         current_tau_type = boost::none;
-        const auto gen_match = GetGenLeptonMatch((*current_tuple)());
+        const auto gen_match = GetGenLeptonMatch(static_cast<reco_tau::gen_truth::GenLepton::Kind>((*current_tuple)().genLepton_kind), 
+                                                  (*current_tuple)().genLepton_index, (*current_tuple)().tau_pt, (*current_tuple)().tau_eta, 
+                                                  (*current_tuple)().tau_phi, (*current_tuple)().tau_mass, (*current_tuple)().genLepton_vis_pt, 
+                                                  (*current_tuple)().genLepton_vis_eta, (*current_tuple)().genLepton_vis_phi, 
+                                                   (*current_tuple)().genLepton_vis_mass, (*current_tuple)().genJet_index);                                           
         const auto sample_type = static_cast<SampleType>((*current_tuple)().sampleType);
 
         if (!gen_match) continue;

--- a/Analysis/interface/TauSelection.h
+++ b/Analysis/interface/TauSelection.h
@@ -6,12 +6,12 @@
 #include "TauMLTools/Core/interface/exception.h"
 
 namespace analysis {
-    std::optional<GenLeptonMatch> GetGenLeptonMatch(Int_t tau_genLepton_kind,  Int_t genLepton_index,  Float_t tau_pt,  Float_t tau_eta,
+    std::optional<GenLeptonMatch> GetGenLeptonMatch(reco_tau::gen_truth::GenLepton::Kind genLepton_kind,  Int_t genLepton_index,  Float_t tau_pt,  Float_t tau_eta,
      Float_t tau_phi,  Float_t tau_mass,  Float_t genLepton_vis_pt,  Float_t genLepton_vis_eta,  Float_t genLepton_vis_phi,  Float_t genLepton_vis_mass,
      Int_t genJet_index)
     {   
         using GTGenLeptonKind = reco_tau::gen_truth::GenLepton::Kind;
-        const GTGenLeptonKind genLepton_kind = static_cast<GTGenLeptonKind> (tau_genLepton_kind);
+        // const GTGenLeptonKind genLepton_kind = static_cast<GTGenLeptonKind> (tau_genLepton_kind);
 
         if (genLepton_index >= 0){
             LorentzVectorM genv(tau_pt, tau_eta, tau_phi, tau_mass);
@@ -46,7 +46,7 @@ namespace analysis {
             }
             else {
                 throw exception("genLepton_kind = %1% should not happend when genLepton_index is %2%")
-                    %tau_genLepton_kind %genLepton_index;
+                    %static_cast<int>(genLepton_kind) %genLepton_index;
             }
         }
         else if (genJet_index >= 0){

--- a/Analysis/interface/TauSelection.h
+++ b/Analysis/interface/TauSelection.h
@@ -11,7 +11,6 @@ namespace analysis {
      Int_t genJet_index)
     {   
         using GTGenLeptonKind = reco_tau::gen_truth::GenLepton::Kind;
-        // const GTGenLeptonKind genLepton_kind = static_cast<GTGenLeptonKind> (tau_genLepton_kind);
 
         if (genLepton_index >= 0){
             LorentzVectorM genv(tau_pt, tau_eta, tau_phi, tau_mass);

--- a/Analysis/python/recompute_tautype.py
+++ b/Analysis/python/recompute_tautype.py
@@ -8,11 +8,11 @@ R.gInterpreter.ProcessLine('''
 #include "TauMLTools/Analysis/interface/TauSelection.h"
 #include "TauMLTools/Analysis/interface/AnalysisTypes.h"
 
-int GetMyTauType(Int_t tau_genLepton_kind,  Int_t genLepton_index,  Float_t tau_pt,  Float_t tau_eta,
+int GetMyTauType(Int_t genLepton_kind,  Int_t genLepton_index,  Float_t tau_pt,  Float_t tau_eta,
      Float_t tau_phi,  Float_t tau_mass,  Float_t genLepton_vis_pt,  Float_t genLepton_vis_eta,  Float_t genLepton_vis_phi,  
      Float_t genLepton_vis_mass, Int_t genJet_index, Int_t sampleType)
      {
-        const auto gen_match = analysis::GetGenLeptonMatch(tau_genLepton_kind, genLepton_index, tau_pt, tau_eta, tau_phi, tau_mass, 
+        const auto gen_match = analysis::GetGenLeptonMatch(static_cast<reco_tau::gen_truth::GenLepton::Kind>(genLepton_kind), genLepton_index, tau_pt, tau_eta, tau_phi, tau_mass, 
                                                             genLepton_vis_pt, genLepton_vis_eta, genLepton_vis_phi, 
                                                             genLepton_vis_mass, genJet_index);
         const auto sample_type= static_cast<analysis::SampleType> (sampleType);
@@ -35,4 +35,3 @@ def compute(df):
                         genLepton_vis_pt, genLepton_vis_eta, genLepton_vis_phi, genLepton_vis_mass, genJet_index, sampleType)""")
     print("Tau Types Recomputed")
     return df
-

--- a/Core/interface/RootExt.h
+++ b/Core/interface/RootExt.h
@@ -18,7 +18,7 @@ This file is part of https://github.com/hh-italian-group/TauMLTools. */
 
 namespace root_ext {
 
-std::shared_ptr<TFile> CreateRootFile(const std::string& file_name, ROOT::ECompressionAlgorithm compression = ROOT::kZLIB,
+std::shared_ptr<TFile> inline CreateRootFile(const std::string& file_name, ROOT::ECompressionAlgorithm compression = ROOT::kZLIB,
                                              int compression_level = 9){
     std::shared_ptr<TFile> file(TFile::Open(file_name.c_str(), "RECREATE", "", compression * 100 + compression_level));
     if(!file || file->IsZombie())
@@ -26,7 +26,7 @@ std::shared_ptr<TFile> CreateRootFile(const std::string& file_name, ROOT::ECompr
     return file;
 }
 
-std::shared_ptr<TFile> OpenRootFile(const std::string& file_name){
+std::shared_ptr<TFile> inline OpenRootFile(const std::string& file_name){
     std::shared_ptr<TFile> file(TFile::Open(file_name.c_str(), "READ"));
     if(!file || file->IsZombie())
         throw analysis::exception("File '%1%' not opened.") % file_name;

--- a/Training/interface/DataLoader_main.h
+++ b/Training/interface/DataLoader_main.h
@@ -242,7 +242,7 @@ public:
           tauTuple->GetEntry(current_entry);
           auto& tau = const_cast<tau_tuple::Tau&>(tauTuple->data());
 
-          const auto gen_match = analysis::GetGenLeptonMatch(tau.genLepton_kind, tau.genLepton_index, tau.tau_pt, tau.tau_eta, tau.tau_phi,
+          const auto gen_match = analysis::GetGenLeptonMatch(static_cast<reco_tau::gen_truth::GenLepton::Kind>(tau.genLepton_kind), tau.genLepton_index, tau.tau_pt, tau.tau_eta, tau.tau_phi,
                                                             tau.tau_mass, tau.genLepton_vis_pt, tau.genLepton_vis_eta, tau.genLepton_vis_phi, 
                                                             tau.genLepton_vis_mass, tau.genJet_index);
           const auto sample_type = static_cast<analysis::SampleType>(tau.sampleType);

--- a/env.sh
+++ b/env.sh
@@ -60,8 +60,8 @@ if [[ $MODE = "prod2018" || $MODE = "phase2" || $MODE = "prod2018UL" ]]; then
         run_cmd ln -s ../../../../Analysis Analysis
         run_cmd ln -s ../../../../Core Core
         run_cmd ln -s ../../../../Production Production
-        run_cmd scram b -j8
         run_cmd touch ../../.installed
+        run_cmd scram b -j8
         run_cmd cd ../../../..
     else
         run_cmd cd soft/$CMSSW_VER/src


### PR DESCRIPTION
- Changed GetGenLeptonMatch genLepton_kind argument type to GenLepton::Kind
- Modified all calls to GetGenLeptonMatch to reflect previous changes to input (individual branches instead of tauTuple)
- CreateRootFile and OpenRootFile definitions inline to prevent compilation errors
- Minor command order change in env.sh