### PR TITLE
Bug fix in PFRelIsolation for electrons

### DIFF
--- a/Production/src/TauAnalysis.cc
+++ b/Production/src/TauAnalysis.cc
@@ -50,11 +50,10 @@ double PFRelIsolation(const pat::Muon& muon)
 
 double PFRelIsolation(const pat::Electron& electron, float rho)
 {   
-    const std::vector<float> eta_lower = {0.0, 1.0, 1.479, 2.0, 2.2, 2.3, 2.4};
+    const std::vector<float> eta_upper = {1.0, 1.479, 2.0, 2.2, 2.3, 2.4, 5.0}; // upper bounds of eta ranges
     const std::vector<float> ea_values = {0.1440, 0.1562, 0.1032, 0.0859, 0.1116, 0.1321, 0.1654};
-
-    auto eta_bin = std::lower_bound(eta_lower.begin(), eta_lower.end(), std::abs(electron.eta())); // iterator pointing to corresponding eta value
-    float ea = ea_values.at(std::distance(eta_lower.begin(), eta_bin)); // get EA at that index
+    auto eta_bin = std::upper_bound(eta_upper.begin(), eta_upper.end(), std::abs(electron.eta())); // iterator pointing to corresponding eta value
+    float ea = ea_values.at(std::distance(eta_upper.begin(), eta_bin)); // get EA at that index
 
     const double sum_neutral = electron.neutralHadronIso()
                              + electron.photonIso()

--- a/Production/src/TauAnalysis.cc
+++ b/Production/src/TauAnalysis.cc
@@ -53,7 +53,8 @@ double PFRelIsolation(const pat::Electron& electron, float rho)
     const std::vector<float> eta_upper = {1.0, 1.479, 2.0, 2.2, 2.3, 2.4, 5.0}; // upper bounds of eta ranges
     const std::vector<float> ea_values = {0.1440, 0.1562, 0.1032, 0.0859, 0.1116, 0.1321, 0.1654};
     auto eta_bin = std::upper_bound(eta_upper.begin(), eta_upper.end(), std::abs(electron.eta())); // iterator pointing to corresponding eta value
-    float ea = ea_values.at(std::distance(eta_upper.begin(), eta_bin)); // get EA at that index
+    auto ea_index = std::min<size_t>(std::distance(eta_upper.begin(), eta_bin), ea_values.size() - 1); // return corresponding index, or last bin if eta>=5
+    float ea = ea_values.at(ea_index); // get EA at that index
 
     const double sum_neutral = electron.neutralHadronIso()
                              + electron.photonIso()


### PR DESCRIPTION
Fix an indexing bug while getting EA value from eta value for electron PF Isolation