### PR TITLE
Update to Phase 2 configs, and "fix" to never load NANs in DataLoader

### DIFF
--- a/Training/configs/ScalingParameters_Phase2_contv2p5.json
+++ b/Training/configs/ScalingParameters_Phase2_contv2p5.json
@@ -1,0 +1,3252 @@
+{
+    "TauFlat": {
+        "rho": {
+            "global": {
+                "mean": 100.0,
+                "std": 100.0,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "tau_pt": {
+            "global": {
+                "mean": 510.0,
+                "std": 490.0,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "tau_eta": {
+            "global": {
+                "mean": 0.0,
+                "std": 3.0,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "tau_phi": {
+            "global": {
+                "mean": 0.0,
+                "std": 3.141592653589793,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "tau_mass": {
+            "global": {
+                "mean": 0.5718,
+                "std": 0.5081,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.5851,
+                "num": 710346
+            }
+        },
+        "tau_E_over_pt": {
+            "global": {
+                "mean": 2.181,
+                "std": 1.593,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 7.292,
+                "num": 710346
+            }
+        },
+        "tau_charge": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "tau_n_charged_prongs": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "tau_n_neutral_prongs": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "tau_chargedIsoPtSum": {
+            "global": {
+                "mean": 14.32,
+                "std": 41.7,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 1944.0,
+                "num": 710346
+            }
+        },
+        "tau_chargedIsoPtSumdR03_over_dR05": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "tau_footprintCorrection": {
+            "global": {
+                "mean": 2.243,
+                "std": 6.779,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 50.99,
+                "num": 710346
+            }
+        },
+        "tau_neutralIsoPtSum": {
+            "global": {
+                "mean": 12.67,
+                "std": 39.88,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 1751.0,
+                "num": 710346
+            }
+        },
+        "tau_neutralIsoPtSumWeight_over_neutralIsoPtSum": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "tau_neutralIsoPtSumWeightdR03_over_neutralIsoPtSum": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "tau_neutralIsoPtSumdR03_over_dR05": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "tau_photonPtSumOutsideSignalCone": {
+            "global": {
+                "mean": 0.4827,
+                "std": 2.298,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 5.513,
+                "num": 710346
+            }
+        },
+        "tau_puCorrPtSum": {
+            "global": {
+                "mean": 101.3,
+                "std": 32.93,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 11350.0,
+                "num": 710346
+            }
+        },
+        "tau_dxy_valid": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "tau_dxy": {
+            "global": {
+                "mean": 0.001571,
+                "std": 0.008156,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 6.899e-05,
+                "num": 710238
+            }
+        },
+        "tau_dxy_sig": {
+            "global": {
+                "mean": 3.935,
+                "std": 8.897,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 94.64,
+                "num": 710238
+            }
+        },
+        "tau_ip3d_valid": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "tau_ip3d": {
+            "global": {
+                "mean": 0.002075,
+                "std": 0.01112,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.000128,
+                "num": 710238
+            }
+        },
+        "tau_ip3d_sig": {
+            "global": {
+                "mean": 4.328,
+                "std": 8.502,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 91.02,
+                "num": 710238
+            }
+        },
+        "tau_dz": {
+            "global": {
+                "mean": 0.001592,
+                "std": 0.8673,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.7522,
+                "num": 710346
+            }
+        },
+        "tau_dz_sig_valid": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "tau_dz_sig": {
+            "global": {
+                "mean": 93.74,
+                "std": 862.9,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 753400.0,
+                "num": 710235
+            }
+        },
+        "tau_flightLength_x": {
+            "global": {
+                "mean": 0.0003602,
+                "std": 0.3587,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.1287,
+                "num": 710346
+            }
+        },
+        "tau_flightLength_y": {
+            "global": {
+                "mean": -1.718e-05,
+                "std": 0.3585,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.1285,
+                "num": 710346
+            }
+        },
+        "tau_flightLength_z": {
+            "global": {
+                "mean": -0.001134,
+                "std": 1.599,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 2.557,
+                "num": 710346
+            }
+        },
+        "tau_flightLength_sig": {
+            "global": {
+                "mean": -2.712,
+                "std": 19.88,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 402.6,
+                "num": 710346
+            }
+        },
+        "tau_pt_weighted_deta_strip": {
+            "global": {
+                "mean": 0.5,
+                "std": 0.5,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "tau_pt_weighted_dphi_strip": {
+            "global": {
+                "mean": 0.5,
+                "std": 0.5,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "tau_pt_weighted_dr_signal": {
+            "global": {
+                "mean": 0.007457,
+                "std": 0.01698,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.000344,
+                "num": 710346
+            }
+        },
+        "tau_pt_weighted_dr_iso": {
+            "global": {
+                "mean": 0.5,
+                "std": 0.5,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "tau_leadingTrackNormChi2": {
+            "global": {
+                "mean": 1.072,
+                "std": 0.5388,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 1.439,
+                "num": 710346
+            }
+        },
+        "tau_e_ratio_valid": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "tau_e_ratio": {
+            "global": {
+                "mean": 0.5,
+                "std": 0.5,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "tau_gj_angle_diff_valid": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "tau_gj_angle_diff": {
+            "global": {
+                "mean": 1.5707963267948966,
+                "std": 1.5707963267948966,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "tau_n_photons": {
+            "global": {
+                "mean": 4.13,
+                "std": 3.313,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 28.03,
+                "num": 710346
+            }
+        },
+        "tau_emFraction": {
+            "global": {
+                "mean": 0.0,
+                "std": 1.0,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "tau_inside_ecal_crack": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "tau_leadChargedCand_etaAtEcalEntrance_minus_tau_eta": {
+            "global": {
+                "mean": -0.0008631,
+                "std": 0.9046,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.8182,
+                "num": 710346
+            }
+        }
+    },
+    "GridGlobal": {
+        "rho": {
+            "global": {
+                "mean": 100.0,
+                "std": 100.0,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "tau_pt": {
+            "global": {
+                "mean": 510.0,
+                "std": 490.0,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "tau_eta": {
+            "global": {
+                "mean": 0.0,
+                "std": 3.0,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "tau_inside_ecal_crack": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        }
+    },
+    "PfCand_electron": {
+        "pfCand_ele_valid": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "pfCand_ele_rel_pt": {
+            "inner": {
+                "mean": 0.8424,
+                "std": 0.6145,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 1.087,
+                "num": 211912
+            },
+            "outer": {
+                "mean": 0.1106,
+                "std": 1.069,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 1.155,
+                "num": 102716
+            }
+        },
+        "pfCand_ele_deta": {
+            "inner": {
+                "mean": 0.0,
+                "std": 0.1,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            },
+            "outer": {
+                "mean": 0.0,
+                "std": 0.5,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "pfCand_ele_dphi": {
+            "inner": {
+                "mean": 0.0,
+                "std": 0.1,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            },
+            "outer": {
+                "mean": 0.0,
+                "std": 0.5,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "pfCand_ele_pvAssociationQuality": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "pfCand_ele_puppiWeight": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "pfCand_ele_charge": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "pfCand_ele_lostInnerHits": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "pfCand_ele_nPixelHits": {
+            "global": {
+                "mean": 7.5,
+                "std": 7.5,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "pfCand_ele_vertex_dx": {
+            "inner": {
+                "mean": -1.594e-05,
+                "std": 0.01716,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.0002946,
+                "num": 211912
+            },
+            "outer": {
+                "mean": -0.000121,
+                "std": 0.11,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.01209,
+                "num": 102716
+            }
+        },
+        "pfCand_ele_vertex_dy": {
+            "inner": {
+                "mean": -1.615e-05,
+                "std": 0.01745,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.0003045,
+                "num": 211912
+            },
+            "outer": {
+                "mean": 5.664e-06,
+                "std": 0.1115,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.01243,
+                "num": 102716
+            }
+        },
+        "pfCand_ele_vertex_dz": {
+            "inner": {
+                "mean": 0.001503,
+                "std": 1.209,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 1.462,
+                "num": 211912
+            },
+            "outer": {
+                "mean": 0.002146,
+                "std": 5.572,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 31.05,
+                "num": 102716
+            }
+        },
+        "pfCand_ele_vertex_dt": {
+            "inner": {
+                "mean": null,
+                "std": null,
+                "lim_min": -5,
+                "lim_max": 5
+            },
+            "outer": {
+                "mean": null,
+                "std": null,
+                "lim_min": -5,
+                "lim_max": 5
+            }
+        },
+        "pfCand_ele_vertex_dx_tauFL": {
+            "inner": {
+                "mean": -0.0001738,
+                "std": 0.5551,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.3082,
+                "num": 211912
+            },
+            "outer": {
+                "mean": -0.001255,
+                "std": 0.4267,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.182,
+                "num": 102716
+            }
+        },
+        "pfCand_ele_vertex_dy_tauFL": {
+            "inner": {
+                "mean": -0.00201,
+                "std": 0.5364,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.2877,
+                "num": 211912
+            },
+            "outer": {
+                "mean": -0.0001182,
+                "std": 0.4208,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.1771,
+                "num": 102716
+            }
+        },
+        "pfCand_ele_vertex_dz_tauFL": {
+            "inner": {
+                "mean": 0.008298,
+                "std": 3.608,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 13.02,
+                "num": 211912
+            },
+            "outer": {
+                "mean": 0.003788,
+                "std": 6.163,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 37.98,
+                "num": 102716
+            }
+        },
+        "pfCand_ele_hasTrackDetails": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "pfCand_ele_dxy": {
+            "inner": {
+                "mean": 3.245e-05,
+                "std": 0.02022,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.0004089,
+                "num": 211481
+            },
+            "outer": {
+                "mean": 0.0008399,
+                "std": 0.09652,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.009317,
+                "num": 84838
+            }
+        },
+        "pfCand_ele_dxy_sig": {
+            "inner": {
+                "mean": 2.908,
+                "std": 6.137,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 46.12,
+                "num": 211481
+            },
+            "outer": {
+                "mean": 6.696,
+                "std": 10.57,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 156.6,
+                "num": 84838
+            }
+        },
+        "pfCand_ele_dz": {
+            "inner": {
+                "mean": 0.001685,
+                "std": 1.189,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 1.414,
+                "num": 211481
+            },
+            "outer": {
+                "mean": 0.02434,
+                "std": 5.509,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 30.35,
+                "num": 84838
+            }
+        },
+        "pfCand_ele_dz_sig": {
+            "inner": {
+                "mean": 105.5,
+                "std": 877.8,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 781600.0,
+                "num": 211481
+            },
+            "outer": {
+                "mean": 827.1,
+                "std": 1507.0,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 2954000.0,
+                "num": 84838
+            }
+        },
+        "pfCand_ele_time": {
+            "inner": {
+                "mean": null,
+                "std": null,
+                "lim_min": -5,
+                "lim_max": 5
+            },
+            "outer": {
+                "mean": null,
+                "std": null,
+                "lim_min": -5,
+                "lim_max": 5
+            }
+        },
+        "pfCand_ele_time_sig": {
+            "inner": {
+                "mean": null,
+                "std": null,
+                "lim_min": -5,
+                "lim_max": 5
+            },
+            "outer": {
+                "mean": null,
+                "std": null,
+                "lim_min": -5,
+                "lim_max": 5
+            }
+        },
+        "pfCand_ele_track_chi2_ndof": {
+            "inner": {
+                "mean": 1.305,
+                "std": 5.948,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 37.08,
+                "num": 211481
+            },
+            "outer": {
+                "mean": 2.902,
+                "std": 11.02,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 129.9,
+                "num": 84838
+            }
+        },
+        "pfCand_ele_track_ndof": {
+            "inner": {
+                "mean": 11.81,
+                "std": 6.481,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 181.5,
+                "num": 211481
+            },
+            "outer": {
+                "mean": 11.96,
+                "std": 6.747,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 188.5,
+                "num": 84838
+            }
+        }
+    },
+    "PfCand_muon": {
+        "pfCand_muon_valid": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "pfCand_muon_rel_pt": {
+            "inner": {
+                "mean": 0.9535,
+                "std": 0.6853,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 1.379,
+                "num": 188697
+            },
+            "outer": {
+                "mean": 0.06569,
+                "std": 0.8174,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.6725,
+                "num": 208294
+            }
+        },
+        "pfCand_muon_deta": {
+            "inner": {
+                "mean": 0.0,
+                "std": 0.1,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            },
+            "outer": {
+                "mean": 0.0,
+                "std": 0.5,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "pfCand_muon_dphi": {
+            "inner": {
+                "mean": 0.0,
+                "std": 0.1,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            },
+            "outer": {
+                "mean": 0.0,
+                "std": 0.5,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "pfCand_muon_pvAssociationQuality": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "pfCand_muon_fromPV": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "pfCand_muon_puppiWeight": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "pfCand_muon_charge": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "pfCand_muon_lostInnerHits": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "pfCand_muon_nPixelHits": {
+            "global": {
+                "mean": 5.5,
+                "std": 5.5,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "pfCand_muon_vertex_dx": {
+            "inner": {
+                "mean": -3.664e-05,
+                "std": 0.02,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.0004002,
+                "num": 188697
+            },
+            "outer": {
+                "mean": -7.842e-05,
+                "std": 0.06539,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.004275,
+                "num": 208294
+            }
+        },
+        "pfCand_muon_vertex_dy": {
+            "inner": {
+                "mean": 1.199e-05,
+                "std": 0.02026,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.0004105,
+                "num": 188697
+            },
+            "outer": {
+                "mean": -0.0001811,
+                "std": 0.06323,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.003998,
+                "num": 208294
+            }
+        },
+        "pfCand_muon_vertex_dz": {
+            "inner": {
+                "mean": -0.001638,
+                "std": 1.248,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 1.558,
+                "num": 188697
+            },
+            "outer": {
+                "mean": 0.0152,
+                "std": 6.064,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 36.77,
+                "num": 208294
+            }
+        },
+        "pfCand_muon_vertex_dt": {
+            "inner": {
+                "mean": null,
+                "std": null,
+                "lim_min": -5,
+                "lim_max": 5
+            },
+            "outer": {
+                "mean": null,
+                "std": null,
+                "lim_min": -5,
+                "lim_max": 5
+            }
+        },
+        "pfCand_muon_vertex_dx_tauFL": {
+            "inner": {
+                "mean": -0.0003709,
+                "std": 0.188,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.03535,
+                "num": 188697
+            },
+            "outer": {
+                "mean": 1.847e-05,
+                "std": 0.4649,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.2161,
+                "num": 208294
+            }
+        },
+        "pfCand_muon_vertex_dy_tauFL": {
+            "inner": {
+                "mean": 0.0004101,
+                "std": 0.1894,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.03588,
+                "num": 188697
+            },
+            "outer": {
+                "mean": -0.002452,
+                "std": 0.4612,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.2127,
+                "num": 208294
+            }
+        },
+        "pfCand_muon_vertex_dz_tauFL": {
+            "inner": {
+                "mean": -0.0002903,
+                "std": 1.374,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 1.889,
+                "num": 188697
+            },
+            "outer": {
+                "mean": 0.01452,
+                "std": 6.464,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 41.78,
+                "num": 208294
+            }
+        },
+        "pfCand_muon_hasTrackDetails": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "pfCand_muon_dxy": {
+            "inner": {
+                "mean": 4.724e-05,
+                "std": 0.02816,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.0007929,
+                "num": 188695
+            },
+            "outer": {
+                "mean": -0.0003077,
+                "std": 0.0908,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.008245,
+                "num": 208269
+            }
+        },
+        "pfCand_muon_dxy_sig": {
+            "inner": {
+                "mean": 2.692,
+                "std": 17.5,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 313.4,
+                "num": 188695
+            },
+            "outer": {
+                "mean": 4.264,
+                "std": 25.46,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 666.4,
+                "num": 208269
+            }
+        },
+        "pfCand_muon_dz": {
+            "inner": {
+                "mean": -0.0007676,
+                "std": 1.248,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 1.558,
+                "num": 188695
+            },
+            "outer": {
+                "mean": 0.01624,
+                "std": 6.063,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 36.76,
+                "num": 208269
+            }
+        },
+        "pfCand_muon_dz_sig": {
+            "inner": {
+                "mean": 69.4,
+                "std": 742.1,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 555500.0,
+                "num": 188695
+            },
+            "outer": {
+                "mean": 652.1,
+                "std": 832.1,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 1118000.0,
+                "num": 208269
+            }
+        },
+        "pfCand_muon_time": {
+            "inner": {
+                "mean": null,
+                "std": null,
+                "lim_min": -5,
+                "lim_max": 5
+            },
+            "outer": {
+                "mean": null,
+                "std": null,
+                "lim_min": -5,
+                "lim_max": 5
+            }
+        },
+        "pfCand_muon_time_sig": {
+            "inner": {
+                "mean": null,
+                "std": null,
+                "lim_min": -5,
+                "lim_max": 5
+            },
+            "outer": {
+                "mean": null,
+                "std": null,
+                "lim_min": -5,
+                "lim_max": 5
+            }
+        },
+        "pfCand_muon_track_chi2_ndof": {
+            "inner": {
+                "mean": 0.4363,
+                "std": 0.6667,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.6349,
+                "num": 188666
+            },
+            "outer": {
+                "mean": 0.8343,
+                "std": 0.8017,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 1.339,
+                "num": 208198
+            }
+        },
+        "pfCand_muon_track_ndof": {
+            "inner": {
+                "mean": 18.07,
+                "std": 4.928,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 350.9,
+                "num": 188666
+            },
+            "outer": {
+                "mean": 21.51,
+                "std": 5.72,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 495.6,
+                "num": 208198
+            }
+        }
+    },
+    "PfCand_chHad": {
+        "pfCand_chHad_valid": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "pfCand_chHad_rel_pt": {
+            "inner": {
+                "mean": 0.1902,
+                "std": 0.3578,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.1641,
+                "num": 1866561
+            },
+            "outer": {
+                "mean": 0.02063,
+                "std": 0.06009,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.004037,
+                "num": 41577016
+            }
+        },
+        "pfCand_chHad_deta": {
+            "inner": {
+                "mean": 0.0,
+                "std": 0.1,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            },
+            "outer": {
+                "mean": 0.0,
+                "std": 0.5,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "pfCand_chHad_dphi": {
+            "inner": {
+                "mean": 0.0,
+                "std": 0.1,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            },
+            "outer": {
+                "mean": 0.0,
+                "std": 0.5,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "pfCand_chHad_tauLeadChargedHadrCand": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "pfCand_chHad_pvAssociationQuality": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "pfCand_chHad_fromPV": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "pfCand_chHad_puppiWeight": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "pfCand_chHad_puppiWeightNoLep": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "pfCand_chHad_charge": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "pfCand_chHad_lostInnerHits": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "pfCand_chHad_nPixelHits": {
+            "global": {
+                "mean": 6.0,
+                "std": 6.0,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "pfCand_chHad_vertex_dx": {
+            "inner": {
+                "mean": -3.22e-05,
+                "std": 0.0326,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.001063,
+                "num": 1866561
+            },
+            "outer": {
+                "mean": 7.994e-06,
+                "std": 0.04616,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.002131,
+                "num": 41577016
+            }
+        },
+        "pfCand_chHad_vertex_dy": {
+            "inner": {
+                "mean": 1.892e-05,
+                "std": 0.03277,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.001074,
+                "num": 1866561
+            },
+            "outer": {
+                "mean": 1.326e-05,
+                "std": 0.04631,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.002145,
+                "num": 41577016
+            }
+        },
+        "pfCand_chHad_vertex_dz": {
+            "inner": {
+                "mean": 0.001798,
+                "std": 4.021,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 16.16,
+                "num": 1866561
+            },
+            "outer": {
+                "mean": 0.00378,
+                "std": 5.925,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 35.11,
+                "num": 41577016
+            }
+        },
+        "pfCand_chHad_vertex_dt": {
+            "inner": {
+                "mean": null,
+                "std": null,
+                "lim_min": -5,
+                "lim_max": 5
+            },
+            "outer": {
+                "mean": null,
+                "std": null,
+                "lim_min": -5,
+                "lim_max": 5
+            }
+        },
+        "pfCand_chHad_vertex_dx_tauFL": {
+            "inner": {
+                "mean": -0.0005992,
+                "std": 0.413,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.1706,
+                "num": 1866561
+            },
+            "outer": {
+                "mean": -0.0005101,
+                "std": 0.3523,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.1241,
+                "num": 41577016
+            }
+        },
+        "pfCand_chHad_vertex_dy_tauFL": {
+            "inner": {
+                "mean": 0.0003633,
+                "std": 0.4153,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.1724,
+                "num": 1866561
+            },
+            "outer": {
+                "mean": -2.036e-05,
+                "std": 0.3541,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.1254,
+                "num": 41577016
+            }
+        },
+        "pfCand_chHad_vertex_dz_tauFL": {
+            "inner": {
+                "mean": 0.004573,
+                "std": 4.324,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 18.69,
+                "num": 1866561
+            },
+            "outer": {
+                "mean": 0.004647,
+                "std": 6.099,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 37.2,
+                "num": 41577016
+            }
+        },
+        "pfCand_chHad_hasTrackDetails": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "pfCand_chHad_dxy": {
+            "inner": {
+                "mean": 8.158e-05,
+                "std": 0.03025,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.0009151,
+                "num": 1592300
+            },
+            "outer": {
+                "mean": 0.0002569,
+                "std": 0.04398,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.001935,
+                "num": 28120792
+            }
+        },
+        "pfCand_chHad_dxy_sig": {
+            "inner": {
+                "mean": 4.518,
+                "std": 11.8,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 159.6,
+                "num": 1592300
+            },
+            "outer": {
+                "mean": 1.772,
+                "std": 5.968,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 38.76,
+                "num": 28120792
+            }
+        },
+        "pfCand_chHad_dz": {
+            "inner": {
+                "mean": 0.006913,
+                "std": 3.547,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 12.58,
+                "num": 1592300
+            },
+            "outer": {
+                "mean": 0.004969,
+                "std": 5.843,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 34.14,
+                "num": 28120792
+            }
+        },
+        "pfCand_chHad_dz_sig": {
+            "inner": {
+                "mean": 287.4,
+                "std": 728.6,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 613500.0,
+                "num": 1592300
+            },
+            "outer": {
+                "mean": 695.1,
+                "std": 756.6,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 1056000.0,
+                "num": 28120792
+            }
+        },
+        "pfCand_chHad_time": {
+            "inner": {
+                "mean": null,
+                "std": null,
+                "lim_min": -5,
+                "lim_max": 5
+            },
+            "outer": {
+                "mean": null,
+                "std": null,
+                "lim_min": -5,
+                "lim_max": 5
+            }
+        },
+        "pfCand_chHad_time_sig": {
+            "inner": {
+                "mean": null,
+                "std": null,
+                "lim_min": -5,
+                "lim_max": 5
+            },
+            "outer": {
+                "mean": null,
+                "std": null,
+                "lim_min": -5,
+                "lim_max": 5
+            }
+        },
+        "pfCand_chHad_track_chi2_ndof": {
+            "inner": {
+                "mean": 0.5699,
+                "std": 0.8056,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.9737,
+                "num": 1592300
+            },
+            "outer": {
+                "mean": 0.6393,
+                "std": 0.8879,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 1.197,
+                "num": 28120791
+            }
+        },
+        "pfCand_chHad_track_ndof": {
+            "inner": {
+                "mean": 16.18,
+                "std": 5.736,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 294.6,
+                "num": 1592300
+            },
+            "outer": {
+                "mean": 15.17,
+                "std": 6.185,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 268.5,
+                "num": 28120791
+            }
+        },
+        "pfCand_chHad_hcalFraction": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "pfCand_chHad_rawCaloFraction": {
+            "global": {
+                "mean": 1.3,
+                "std": 1.3,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        }
+    },
+    "PfCand_nHad": {
+        "pfCand_nHad_valid": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "pfCand_nHad_rel_pt": {
+            "inner": {
+                "mean": 0.1149,
+                "std": 0.2151,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.05946,
+                "num": 141428
+            },
+            "outer": {
+                "mean": 0.01414,
+                "std": 0.05509,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.003235,
+                "num": 4898076
+            }
+        },
+        "pfCand_nHad_deta": {
+            "inner": {
+                "mean": 0.0,
+                "std": 0.1,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            },
+            "outer": {
+                "mean": 0.0,
+                "std": 0.5,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "pfCand_nHad_dphi": {
+            "inner": {
+                "mean": 0.0,
+                "std": 0.1,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            },
+            "outer": {
+                "mean": 0.0,
+                "std": 0.5,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "pfCand_nHad_puppiWeight": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "pfCand_nHad_puppiWeightNoLep": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "pfCand_nHad_hcalFraction": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        }
+    },
+    "PfCand_gamma": {
+        "pfCand_gamma_valid": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "pfCand_gamma_rel_pt": {
+            "inner": {
+                "mean": 0.1594,
+                "std": 0.4276,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.2083,
+                "num": 827218
+            },
+            "outer": {
+                "mean": 0.01285,
+                "std": 0.07524,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.005826,
+                "num": 20647191
+            }
+        },
+        "pfCand_gamma_deta": {
+            "inner": {
+                "mean": 0.0,
+                "std": 0.1,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            },
+            "outer": {
+                "mean": 0.0,
+                "std": 0.5,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "pfCand_gamma_dphi": {
+            "inner": {
+                "mean": 0.0,
+                "std": 0.1,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            },
+            "outer": {
+                "mean": 0.0,
+                "std": 0.5,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "pfCand_gamma_pvAssociationQuality": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "pfCand_gamma_fromPV": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "pfCand_gamma_puppiWeight": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "pfCand_gamma_puppiWeightNoLep": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "pfCand_gamma_lostInnerHits": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "pfCand_gamma_nPixelHits": {
+            "global": {
+                "mean": 3.5,
+                "std": 3.5,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "pfCand_gamma_vertex_dx": {
+            "inner": {
+                "mean": 1.295e-05,
+                "std": 0.004268,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 1.821e-05,
+                "num": 827218
+            },
+            "outer": {
+                "mean": 4.308e-06,
+                "std": 0.003429,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 1.176e-05,
+                "num": 20647191
+            }
+        },
+        "pfCand_gamma_vertex_dy": {
+            "inner": {
+                "mean": -8.435e-06,
+                "std": 0.003182,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 1.012e-05,
+                "num": 827218
+            },
+            "outer": {
+                "mean": 1.919e-06,
+                "std": 0.003318,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 1.101e-05,
+                "num": 20647191
+            }
+        },
+        "pfCand_gamma_vertex_dz": {
+            "inner": {
+                "mean": -0.001344,
+                "std": 0.6095,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.3715,
+                "num": 827218
+            },
+            "outer": {
+                "mean": -0.0005881,
+                "std": 0.5228,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.2733,
+                "num": 20647181
+            }
+        },
+        "pfCand_gamma_vertex_dt": {
+            "inner": {
+                "mean": null,
+                "std": null,
+                "lim_min": -5,
+                "lim_max": 5
+            },
+            "outer": {
+                "mean": null,
+                "std": null,
+                "lim_min": -5,
+                "lim_max": 5
+            }
+        },
+        "pfCand_gamma_vertex_dx_tauFL": {
+            "inner": {
+                "mean": -0.0006508,
+                "std": 0.3957,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.1566,
+                "num": 827218
+            },
+            "outer": {
+                "mean": -0.0009704,
+                "std": 0.4157,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.1728,
+                "num": 20647191
+            }
+        },
+        "pfCand_gamma_vertex_dy_tauFL": {
+            "inner": {
+                "mean": -0.0004855,
+                "std": 0.394,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.1553,
+                "num": 827218
+            },
+            "outer": {
+                "mean": 0.000131,
+                "std": 0.4125,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.1701,
+                "num": 20647191
+            }
+        },
+        "pfCand_gamma_vertex_dz_tauFL": {
+            "inner": {
+                "mean": 0.004292,
+                "std": 2.006,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 4.023,
+                "num": 827218
+            },
+            "outer": {
+                "mean": 0.001519,
+                "std": 2.441,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 5.958,
+                "num": 20647181
+            }
+        },
+        "pfCand_gamma_hasTrackDetails": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "pfCand_gamma_dxy": {
+            "inner": {
+                "mean": 0.001246,
+                "std": 0.02973,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.0008856,
+                "num": 71
+            },
+            "outer": {
+                "mean": 0.007348,
+                "std": 0.03917,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.001588,
+                "num": 5
+            }
+        },
+        "pfCand_gamma_dxy_sig": {
+            "inner": {
+                "mean": 7.58,
+                "std": 10.0,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 157.5,
+                "num": 71
+            },
+            "outer": {
+                "mean": 12.2,
+                "std": 8.802,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 226.3,
+                "num": 5
+            }
+        },
+        "pfCand_gamma_dz": {
+            "inner": {
+                "mean": -0.4247,
+                "std": 6.273,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 39.53,
+                "num": 71
+            },
+            "outer": {
+                "mean": 4.698,
+                "std": 5.297,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 50.14,
+                "num": 5
+            }
+        },
+        "pfCand_gamma_dz_sig": {
+            "inner": {
+                "mean": 1903.0,
+                "std": 3515.0,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 15970000.0,
+                "num": 71
+            },
+            "outer": {
+                "mean": 3080.0,
+                "std": 4449.0,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 29280000.0,
+                "num": 5
+            }
+        },
+        "pfCand_gamma_time": {
+            "inner": {
+                "mean": null,
+                "std": null,
+                "lim_min": -5,
+                "lim_max": 5
+            },
+            "outer": {
+                "mean": null,
+                "std": null,
+                "lim_min": -5,
+                "lim_max": 5
+            }
+        },
+        "pfCand_gamma_time_sig": {
+            "inner": {
+                "mean": null,
+                "std": null,
+                "lim_min": -5,
+                "lim_max": 5
+            },
+            "outer": {
+                "mean": null,
+                "std": null,
+                "lim_min": -5,
+                "lim_max": 5
+            }
+        },
+        "pfCand_gamma_track_chi2_ndof": {
+            "inner": {
+                "mean": 18.11,
+                "std": 39.42,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 1882.0,
+                "num": 71
+            },
+            "outer": {
+                "mean": 32.8,
+                "std": 38.05,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 2524.0,
+                "num": 5
+            }
+        },
+        "pfCand_gamma_track_ndof": {
+            "inner": {
+                "mean": 7.873,
+                "std": 1.51,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 64.27,
+                "num": 71
+            },
+            "outer": {
+                "mean": 5.8,
+                "std": 1.6,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 36.2,
+                "num": 5
+            }
+        }
+    },
+    "Electron": {
+        "ele_valid": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "ele_rel_pt": {
+            "inner": {
+                "mean": 1.005,
+                "std": 1.014,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 2.039,
+                "num": 272814
+            },
+            "outer": {
+                "mean": 0.3915,
+                "std": 1.379,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 2.055,
+                "num": 135831
+            }
+        },
+        "ele_deta": {
+            "inner": {
+                "mean": 0.0,
+                "std": 0.1,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            },
+            "outer": {
+                "mean": 0.0,
+                "std": 0.5,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "ele_dphi": {
+            "inner": {
+                "mean": 0.0,
+                "std": 0.1,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            },
+            "outer": {
+                "mean": 0.0,
+                "std": 0.5,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "ele_cc_valid": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "ele_cc_ele_rel_energy": {
+            "inner": {
+                "mean": 1.219,
+                "std": 0.5406,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 1.779,
+                "num": 174195
+            },
+            "outer": {
+                "mean": 0.978,
+                "std": 2.605,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 7.74,
+                "num": 51347
+            }
+        },
+        "ele_cc_gamma_rel_energy": {
+            "inner": {
+                "mean": 0.1747,
+                "std": 0.3296,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.1392,
+                "num": 174195
+            },
+            "outer": {
+                "mean": 0.4455,
+                "std": 0.6392,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.607,
+                "num": 51347
+            }
+        },
+        "ele_cc_n_gamma": {
+            "inner": {
+                "mean": 2.046,
+                "std": 1.92,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 7.87,
+                "num": 174195
+            },
+            "outer": {
+                "mean": 1.803,
+                "std": 2.079,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 7.572,
+                "num": 51347
+            }
+        },
+        "ele_rel_trackMomentumAtVtx": {
+            "inner": {
+                "mean": 2.11,
+                "std": 20.89,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 441.0,
+                "num": 272814
+            },
+            "outer": {
+                "mean": 2.508,
+                "std": 102.2,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 10450.0,
+                "num": 135831
+            }
+        },
+        "ele_rel_trackMomentumAtCalo": {
+            "inner": {
+                "mean": 2.11,
+                "std": 20.89,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 441.0,
+                "num": 272814
+            },
+            "outer": {
+                "mean": 2.508,
+                "std": 102.2,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 10450.0,
+                "num": 135831
+            }
+        },
+        "ele_rel_trackMomentumOut": {
+            "inner": {
+                "mean": 1.784,
+                "std": 23.88,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 573.3,
+                "num": 272814
+            },
+            "outer": {
+                "mean": 1.726,
+                "std": 99.4,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 9883.0,
+                "num": 135831
+            }
+        },
+        "ele_rel_trackMomentumAtEleClus": {
+            "inner": {
+                "mean": 1.784,
+                "std": 23.88,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 573.3,
+                "num": 272814
+            },
+            "outer": {
+                "mean": 1.726,
+                "std": 99.4,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 9883.0,
+                "num": 135831
+            }
+        },
+        "ele_rel_trackMomentumAtVtxWithConstraint": {
+            "inner": {
+                "mean": 2.07,
+                "std": 5.072,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 30.01,
+                "num": 272814
+            },
+            "outer": {
+                "mean": 1.957,
+                "std": 41.23,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 1704.0,
+                "num": 135831
+            }
+        },
+        "ele_rel_ecalEnergy": {
+            "inner": {
+                "mean": 2.439,
+                "std": 1.783,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 9.128,
+                "num": 272814
+            },
+            "outer": {
+                "mean": 2.223,
+                "std": 1.889,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 8.512,
+                "num": 135831
+            }
+        },
+        "ele_ecalEnergy_sig": {
+            "inner": {
+                "mean": 45.29,
+                "std": 39.63,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 3621.0,
+                "num": 272814
+            },
+            "outer": {
+                "mean": 10.34,
+                "std": 12.54,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 264.1,
+                "num": 135831
+            }
+        },
+        "ele_eSuperClusterOverP": {
+            "inner": {
+                "mean": 2.077,
+                "std": 3.758,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 18.44,
+                "num": 272814
+            },
+            "outer": {
+                "mean": 2.985,
+                "std": 10.94,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 128.7,
+                "num": 135831
+            }
+        },
+        "ele_eSeedClusterOverP": {
+            "inner": {
+                "mean": 1.602,
+                "std": 3.153,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 12.51,
+                "num": 272814
+            },
+            "outer": {
+                "mean": 1.6,
+                "std": 9.838,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 99.34,
+                "num": 135831
+            }
+        },
+        "ele_eSeedClusterOverPout": {
+            "inner": {
+                "mean": 2.207,
+                "std": 4.36,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 23.89,
+                "num": 272814
+            },
+            "outer": {
+                "mean": 1.761,
+                "std": 4.864,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 26.76,
+                "num": 135831
+            }
+        },
+        "ele_eEleClusterOverPout": {
+            "inner": {
+                "mean": 1.535,
+                "std": 2.753,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 9.938,
+                "num": 272814
+            },
+            "outer": {
+                "mean": 1.041,
+                "std": 2.771,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 8.759,
+                "num": 135831
+            }
+        },
+        "ele_deltaEtaSuperClusterTrackAtVtx": {
+            "inner": {
+                "mean": 6.492e-06,
+                "std": 0.01403,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.0001969,
+                "num": 272814
+            },
+            "outer": {
+                "mean": 0.0001027,
+                "std": 0.04308,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.001856,
+                "num": 135831
+            }
+        },
+        "ele_deltaEtaSeedClusterTrackAtCalo": {
+            "inner": {
+                "mean": -3.824e-06,
+                "std": 0.01394,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.0001942,
+                "num": 272814
+            },
+            "outer": {
+                "mean": -0.0002442,
+                "std": 0.04422,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.001955,
+                "num": 135831
+            }
+        },
+        "ele_deltaEtaEleClusterTrackAtCalo": {
+            "inner": {
+                "mean": -5.448e-06,
+                "std": 0.01382,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.0001911,
+                "num": 272814
+            },
+            "outer": {
+                "mean": -0.0002209,
+                "std": 0.0429,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.001841,
+                "num": 135831
+            }
+        },
+        "ele_deltaPhiEleClusterTrackAtCalo": {
+            "inner": {
+                "mean": 4.593e-05,
+                "std": 0.02341,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.0005479,
+                "num": 272814
+            },
+            "outer": {
+                "mean": 5.576e-05,
+                "std": 0.06296,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.003964,
+                "num": 135831
+            }
+        },
+        "ele_deltaPhiSuperClusterTrackAtVtx": {
+            "inner": {
+                "mean": 9.523e-05,
+                "std": 0.04605,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.002121,
+                "num": 272814
+            },
+            "outer": {
+                "mean": -0.0004276,
+                "std": 0.133,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.01768,
+                "num": 135831
+            }
+        },
+        "ele_deltaPhiSeedClusterTrackAtCalo": {
+            "inner": {
+                "mean": 4.193e-05,
+                "std": 0.0464,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.002153,
+                "num": 272814
+            },
+            "outer": {
+                "mean": -0.0004178,
+                "std": 0.1179,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.0139,
+                "num": 135831
+            }
+        },
+        "ele_mvaInput_earlyBrem": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "ele_mvaInput_lateBrem": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "ele_mvaInput_sigmaEtaEta": {
+            "inner": {
+                "mean": 0.0002632,
+                "std": 0.001201,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 1.512e-06,
+                "num": 174396
+            },
+            "outer": {
+                "mean": 0.0002244,
+                "std": 0.001352,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 1.88e-06,
+                "num": 53614
+            }
+        },
+        "ele_mvaInput_hadEnergy": {
+            "inner": {
+                "mean": 2.268,
+                "std": 10.6,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 117.6,
+                "num": 174396
+            },
+            "outer": {
+                "mean": 3.137,
+                "std": 13.06,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 180.5,
+                "num": 53614
+            }
+        },
+        "ele_mvaInput_deltaEta": {
+            "inner": {
+                "mean": 0.003118,
+                "std": 0.004481,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 2.98e-05,
+                "num": 174396
+            },
+            "outer": {
+                "mean": 0.01031,
+                "std": 0.0315,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.001099,
+                "num": 53614
+            }
+        },
+        "ele_gsfTrack_normalizedChi2": {
+            "inner": {
+                "mean": 4.976,
+                "std": 35.88,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 1312.0,
+                "num": 272814
+            },
+            "outer": {
+                "mean": 52.28,
+                "std": 1867.0,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 3490000.0,
+                "num": 135831
+            }
+        },
+        "ele_gsfTrack_numberOfValidHits": {
+            "inner": {
+                "mean": 9.803,
+                "std": 1.185,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 97.51,
+                "num": 272814
+            },
+            "outer": {
+                "mean": 8.907,
+                "std": 1.421,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 81.35,
+                "num": 135831
+            }
+        },
+        "ele_rel_gsfTrack_pt": {
+            "inner": {
+                "mean": 1.455,
+                "std": 36.29,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 1319.0,
+                "num": 272814
+            },
+            "outer": {
+                "mean": 2.1,
+                "std": 77.27,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 5975.0,
+                "num": 135831
+            }
+        },
+        "ele_gsfTrack_pt_sig": {
+            "inner": {
+                "mean": 6.346,
+                "std": 3.076,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 49.73,
+                "num": 272814
+            },
+            "outer": {
+                "mean": 7.053,
+                "std": 6.956,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 98.14,
+                "num": 135831
+            }
+        },
+        "ele_has_closestCtfTrack": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "ele_closestCtfTrack_normalizedChi2": {
+            "inner": {
+                "mean": 1.241,
+                "std": 0.726,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 2.068,
+                "num": 261906
+            },
+            "outer": {
+                "mean": 1.288,
+                "std": 1.081,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 2.828,
+                "num": 80703
+            }
+        },
+        "ele_closestCtfTrack_numberOfValidHits": {
+            "inner": {
+                "mean": 15.65,
+                "std": 5.13,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 271.2,
+                "num": 261906
+            },
+            "outer": {
+                "mean": 15.6,
+                "std": 6.592,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 286.7,
+                "num": 80703
+            }
+        }
+    },
+    "Muon": {
+        "muon_valid": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "muon_rel_pt": {
+            "inner": {
+                "mean": 1.153,
+                "std": 35.54,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 1264.0,
+                "num": 281398
+            },
+            "outer": {
+                "mean": 0.1419,
+                "std": 5.958,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 35.52,
+                "num": 318842
+            }
+        },
+        "muon_deta": {
+            "inner": {
+                "mean": 0.0,
+                "std": 0.1,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            },
+            "outer": {
+                "mean": 0.0,
+                "std": 0.5,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "muon_dphi": {
+            "inner": {
+                "mean": 0.0,
+                "std": 0.1,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            },
+            "outer": {
+                "mean": 0.0,
+                "std": 0.5,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "muon_dxy": {
+            "inner": {
+                "mean": -1.624e-05,
+                "std": 0.16,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.02559,
+                "num": 281398
+            },
+            "outer": {
+                "mean": -7.344e-05,
+                "std": 0.1345,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.0181,
+                "num": 318842
+            }
+        },
+        "muon_dxy_sig": {
+            "inner": {
+                "mean": 21.24,
+                "std": 105.2,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 11520.0,
+                "num": 281398
+            },
+            "outer": {
+                "mean": 7.819,
+                "std": 49.28,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 2489.0,
+                "num": 318842
+            }
+        },
+        "muon_normalizedChi2_valid": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "muon_normalizedChi2": {
+            "inner": {
+                "mean": 15.0,
+                "std": 269.2,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 72670.0,
+                "num": 188723
+            },
+            "outer": {
+                "mean": 35.42,
+                "std": 274.6,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 76650.0,
+                "num": 48289
+            }
+        },
+        "muon_numberOfValidHits": {
+            "inner": {
+                "mean": 18.63,
+                "std": 4.874,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 370.7,
+                "num": 188723
+            },
+            "outer": {
+                "mean": 17.91,
+                "std": 5.823,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 354.7,
+                "num": 48289
+            }
+        },
+        "muon_segmentCompatibility": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "muon_caloCompatibility": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "muon_pfEcalEnergy_valid": {
+            "global": {
+                "mean": 0,
+                "std": 1,
+                "lim_min": "-inf",
+                "lim_max": "inf",
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "muon_rel_pfEcalEnergy": {
+            "inner": {
+                "mean": 0.05187,
+                "std": 0.2431,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.06179,
+                "num": 251154
+            },
+            "outer": {
+                "mean": 0.05448,
+                "std": 0.2388,
+                "lim_min": -5,
+                "lim_max": 5,
+                "sqmean": 0.06001,
+                "num": 293178
+            }
+        },
+        "muon_n_matches_DT_1": {
+            "global": {
+                "mean": 1.0,
+                "std": 1.0,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "muon_n_matches_DT_2": {
+            "global": {
+                "mean": 1.0,
+                "std": 1.0,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "muon_n_matches_DT_3": {
+            "global": {
+                "mean": 1.0,
+                "std": 1.0,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "muon_n_matches_DT_4": {
+            "global": {
+                "mean": 1.0,
+                "std": 1.0,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "muon_n_matches_CSC_1": {
+            "global": {
+                "mean": 3.0,
+                "std": 3.0,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "muon_n_matches_CSC_2": {
+            "global": {
+                "mean": 1.0,
+                "std": 1.0,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "muon_n_matches_CSC_3": {
+            "global": {
+                "mean": 1.0,
+                "std": 1.0,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "muon_n_matches_CSC_4": {
+            "global": {
+                "mean": 1.0,
+                "std": 1.0,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "muon_n_matches_RPC_1": {
+            "global": {
+                "mean": 3.5,
+                "std": 3.5,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "muon_n_matches_RPC_2": {
+            "global": {
+                "mean": 3.0,
+                "std": 3.0,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "muon_n_matches_RPC_3": {
+            "global": {
+                "mean": 2.0,
+                "std": 2.0,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "muon_n_matches_RPC_4": {
+            "global": {
+                "mean": 2.0,
+                "std": 2.0,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "muon_n_hits_DT_1": {
+            "global": {
+                "mean": 6.0,
+                "std": 6.0,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "muon_n_hits_DT_2": {
+            "global": {
+                "mean": 6.0,
+                "std": 6.0,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "muon_n_hits_DT_3": {
+            "global": {
+                "mean": 6.0,
+                "std": 6.0,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "muon_n_hits_DT_4": {
+            "global": {
+                "mean": 4.0,
+                "std": 4.0,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "muon_n_hits_CSC_1": {
+            "global": {
+                "mean": 12.0,
+                "std": 12.0,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "muon_n_hits_CSC_2": {
+            "global": {
+                "mean": 6.0,
+                "std": 6.0,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "muon_n_hits_CSC_3": {
+            "global": {
+                "mean": 6.0,
+                "std": 6.0,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "muon_n_hits_CSC_4": {
+            "global": {
+                "mean": 6.0,
+                "std": 6.0,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "muon_n_hits_RPC_1": {
+            "global": {
+                "mean": 2.0,
+                "std": 2.0,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "muon_n_hits_RPC_2": {
+            "global": {
+                "mean": 2.0,
+                "std": 2.0,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "muon_n_hits_RPC_3": {
+            "global": {
+                "mean": 1.0,
+                "std": 1.0,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        },
+        "muon_n_hits_RPC_4": {
+            "global": {
+                "mean": 1.0,
+                "std": 1.0,
+                "lim_min": -1.0,
+                "lim_max": 1.0,
+                "sqmean": null,
+                "num": null
+            }
+        }
+    }
+}

--- a/Training/configs/training_phase2.yaml
+++ b/Training/configs/training_phase2.yaml
@@ -68,7 +68,7 @@ SetupNN:
     n_batches_val        : -1 # -1 for all
     n_batches_log        : 1000 # monitor every n batches in tensorboard
     epoch                : 0
-    n_epochs             : 15
+    n_epochs             : 10
     validation_split     : 0.2
     max_queue_size       : 1
     n_load_workers       : 1
@@ -77,7 +77,7 @@ SetupNN:
                             [ GridGlobal, PfCand_muon, Muon ], # muons
                             [ GridGlobal, PfCand_chHad, PfCand_nHad ] # hadrons
                            ]
-    TauLossesSFs         : [0.4, 1.0, 2.0, 0.6]
+    TauLossesSFs         : [0.8, 1.5, 4.0, 1.7]
     optimizer_name       : "Nadam"
     learning_rate        : 0.001
     schedule_decay       : 0.0 #0.0001 # Using step decay instead of schedule decay

--- a/Training/configs/training_phase2_contv2p5.yaml
+++ b/Training/configs/training_phase2_contv2p5.yaml
@@ -3,8 +3,8 @@ Setup:
     iso_cone             :  0.5
     n_inner_cells        :  11
     inner_cell_size      :  0.02
-    n_outer_cells        :  25
-    outer_cell_size      :  0.042
+    n_outer_cells        :  21
+    outer_cell_size      :  0.05
     n_threads            :  1
     debug                :  False
     use_weights          :  True
@@ -27,7 +27,7 @@ Setup:
     adv_parameter        : [1, 10] # k1, k2 for gradients in common layers
     n_adv_tau            : 100 # number of candidates per adversarial batch
     adv_learning_rate    : 0.01
-    use_previous_opt     : False
+    use_previous_opt     : True
 
     # here define variables for the Histogram_2D class
     yaxis                : [
@@ -63,9 +63,9 @@ Setup:
     xmax                 : 3.0
 
 SetupNN:
-    model_name           : "DeepTauPhase2v1"
-    n_batches            : -1 # -1 for all
-    n_batches_val        : -1 # -1 for all
+    model_name           : "DeepTau2018v0"
+    n_batches            : -1
+    n_batches_val        : -1
     n_batches_log        : 1000 # monitor every n batches in tensorboard
     epoch                : 0
     n_epochs             : 15
@@ -80,17 +80,17 @@ SetupNN:
     TauLossesSFs         : [0.4, 1.0, 2.0, 0.6]
     optimizer_name       : "Nadam"
     learning_rate        : 0.001
-    schedule_decay       : 0.0 #0.0001 # Using step decay instead of schedule decay
-    step_decay           : 2 # Halve lr every *this* epochs
+    schedule_decay       : 0.0 # 0.0001 # Using step decay instead of schedule decay
+    step_decay           : 3 # Halve lr every *this* epochs
     tau_net              : { "activation": "PReLU", "dropout_rate": 0.2, "reduction_rate": 1.4, "first_layer_width": "2*n*(1+drop)", "last_layer_width": "n*(1+drop)" }
     comp_net             : { "activation": "PReLU", "dropout_rate": 0.2, "reduction_rate": 1.6, "first_layer_width": "2*n*(1+drop)", "last_layer_width": "n*(1+drop)" }
-    comp_merge_net       : { "activation": "PReLU", "dropout_rate": 0.2, "reduction_rate": 1.65, "first_layer_width": "0.6*n", "last_layer_width": 32 }
-    conv_2d_net          : { "activation": "PReLU", "dropout_rate": 0.2, "reduction_rate": null, "window_size": 3, "pooling": 3 }
-    dense_net            : { "activation": "PReLU", "dropout_rate": 0.2, "reduction_rate": 1, "first_layer_width": 135, "last_layer_width": 135, "min_n_layers": 4 }
+    comp_merge_net       : { "activation": "PReLU", "dropout_rate": 0.2, "reduction_rate": 1.6, "first_layer_width": "n", "last_layer_width": 64 }
+    conv_2d_net          : { "activation": "PReLU", "dropout_rate": 0.2, "reduction_rate": null, "window_size": 3, "pooling": 0 }
+    dense_net            : { "activation": "PReLU", "dropout_rate": 0.2, "reduction_rate": 1, "first_layer_width": 200, "last_layer_width": 200, "min_n_layers": 4 }
     first_layer_reg      : null # eg "L1, reg_fact"
     active_features      : ['TauFlat', 'GridGlobal', 'PfCand_electron', 'PfCand_muon', 'PfCand_chHad', 'PfCand_nHad', 'PfCand_gamma', 'Electron', 'Muon']
     cell_locations       : ['inner', 'outer']
-    loss                 : "WPloss2" # "tau_crossentropy_v2"
+    loss                 : "WPloss2" # should not be specified when using DeepTauModel() class
     using_new_loss       : True
     metrics              : ['accuracy', 'TauLosses.tau_crossentropy_v2', 'TauLosses.We', 'TauLosses.Wmu', 'TauLosses.Wjet', 'TauLosses.WPloss', 'TauLosses.WPloss2']
 
@@ -484,10 +484,10 @@ Features_all :
 Features_disable :
     TauFlat : ["tau_phi"]
     GridGlobal : []
-    PfCand_electron : [ ]
-    PfCand_muon : [ ]
-    PfCand_chHad : [ ]
+    PfCand_electron : ["pfCand_ele_vertex_dt", "pfCand_ele_time", "pfCand_ele_time_sig"]
+    PfCand_muon : ["pfCand_muon_vertex_dt", "pfCand_muon_time", "pfCand_muon_time_sig"]
+    PfCand_chHad : ["pfCand_chHad_vertex_dt", "pfCand_chHad_time", "pfCand_chHad_time_sig"]
     PfCand_nHad : [ ]
-    PfCand_gamma : ["pfCand_gamma_hasTrackDetails", "pfCand_gamma_dxy", "pfCand_gamma_dxy_sig", "pfCand_gamma_dz", "pfCand_gamma_dz_sig", "pfCand_gamma_track_chi2_ndof", "pfCand_gamma_track_ndof", "pfCand_gamma_vertex_dz", "pfCand_gamma_vertex_dz_tauFL", "pfCand_gamma_time", "pfCand_gamma_time_sig", "pfCand_gamma_vertex_dt"]
+    PfCand_gamma : ["pfCand_gamma_vertex_dt", "pfCand_gamma_time", "pfCand_gamma_time_sig"]
     Electron : [ ]
     Muon : [ ]

--- a/Training/configs/training_phase2_contv2p5.yaml
+++ b/Training/configs/training_phase2_contv2p5.yaml
@@ -68,7 +68,7 @@ SetupNN:
     n_batches_val        : -1
     n_batches_log        : 1000 # monitor every n batches in tensorboard
     epoch                : 0
-    n_epochs             : 15
+    n_epochs             : 10
     validation_split     : 0.2
     max_queue_size       : 1
     n_load_workers       : 1
@@ -77,11 +77,11 @@ SetupNN:
                             [ GridGlobal, PfCand_muon, Muon ], # muons
                             [ GridGlobal, PfCand_chHad, PfCand_nHad ] # hadrons
                            ]
-    TauLossesSFs         : [0.4, 1.0, 2.0, 0.6]
+    TauLossesSFs         : [0.8, 1.5, 4.0, 1.7]
     optimizer_name       : "Nadam"
     learning_rate        : 0.001
     schedule_decay       : 0.0 # 0.0001 # Using step decay instead of schedule decay
-    step_decay           : 3 # Halve lr every *this* epochs
+    step_decay           : 2 # Halve lr every *this* epochs
     tau_net              : { "activation": "PReLU", "dropout_rate": 0.2, "reduction_rate": 1.4, "first_layer_width": "2*n*(1+drop)", "last_layer_width": "n*(1+drop)" }
     comp_net             : { "activation": "PReLU", "dropout_rate": 0.2, "reduction_rate": 1.6, "first_layer_width": "2*n*(1+drop)", "last_layer_width": "n*(1+drop)" }
     comp_merge_net       : { "activation": "PReLU", "dropout_rate": 0.2, "reduction_rate": 1.6, "first_layer_width": "n", "last_layer_width": 64 }

--- a/Training/interface/DataLoader_main.h
+++ b/Training/interface/DataLoader_main.h
@@ -472,7 +472,7 @@ public:
                                     std::make_index_sequence<nFeaturesTypes>{});
 
         auto fillGrid = [&](auto _feature_idx, float value) {
-          if(static_cast<int>(_feature_idx) < 0) return;
+          if((static_cast<int>(_feature_idx) < 0) || !(std::isfinite(value))) return;
           const CellObjectType obj_type = FeaturesHelper<decltype(_feature_idx)>::object_type;
           const size_t start = start_indices.at(ElementIndex<decltype(_feature_idx), FeatureTuple>::value);
           data->x_grid.at(obj_type).at(inner).at(start + static_cast<int>(_feature_idx))

--- a/Training/python/train_phase2_contv2p5.yaml
+++ b/Training/python/train_phase2_contv2p5.yaml
@@ -1,0 +1,25 @@
+hydra:
+  run:
+    dir: outputs/${experiment_name}/${training_cfg.SetupNN.model_name}/${now:%Y-%m-%d_%H-%M-%S}
+defaults:
+  - ../configs@_global_.training_cfg: training_phase2_contv2p5
+  - _self_
+
+# mlflow
+path_to_mlflow: mlruns
+experiment_name: ???
+
+# pretrained: null
+pretrained:
+  run_id : e1f3ddb3c4c94128a34a7635c56322eb # e.g: 6076d0ebeb414e38b29e5511e7f7d3ab
+  experiment_id: 4 # e.g: 1
+  starting_model: adv_decay_1e3_Adam_100k_step1_final.tf # e.g: DeepTau2018v0_step1_final.tf
+
+# setup
+scaling_cfg: ../configs/ScalingParameters_Phase2_contv2p5.json # for DataLoader initialisation
+gpu_cfg:
+  gpu_mem  : 7 # in Gb
+  gpu_index: 0
+
+# logs
+log_suffix: step1


### PR DESCRIPTION
- Update of Phase 2 configurations, and also the configurations to be used when taking v2p5 and continuing the training on Phase 2 samples.
- And perhaps more importantly: A fix to never load NANs in DataLoader. This is needed because our Phase 2 ntuples have a few inputs (Photon track information) which are NAN for very few taus (less than 5 I believe). For the regular Phase 2 trainings, we had these inputs disabled, but they are necessary when continuing the training from v2p5, because the inputs are enabled there. So, instead, I added a "fix" in the DataLoader to make sure that any input is finite before is it actually read. I do want to make sure if this implementation is fine for you? Because this means that it won't catch any future instances of NANs (perhaps only in previous steps of the Shuffle&Merge or features scaling workflows).