### PR TITLE
More collections for HLT training nano

### DIFF
--- a/Production/plugins/BuildFile.xml
+++ b/Production/plugins/BuildFile.xml
@@ -1,5 +1,6 @@
 <use name="FWCore/Framework"/>
 <use name="SimGeneral/HepPDTRecord"/>
 <use name="TauMLTools/Production"/>
+<use name="DataFormats/NanoAOD"/>
 
 <flags EDM_PLUGIN="1"/>

--- a/Production/plugins/CaloTableProducer.cc
+++ b/Production/plugins/CaloTableProducer.cc
@@ -29,6 +29,7 @@ public:
     produces<nanoaod::FlatTable>("RecHitEE");
   }
 
+private:
   void produce(edm::StreamID id, edm::Event& event, const edm::EventSetup& setup) const override
   {
     const auto& geometry = setup.getData(geometryToken_);

--- a/Production/plugins/CaloTableProducer.cc
+++ b/Production/plugins/CaloTableProducer.cc
@@ -1,0 +1,139 @@
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/NanoAOD/interface/FlatTable.h"
+
+#include "DataFormats/EcalRecHit/interface/EcalRecHit.h"
+#include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
+#include "DataFormats/HcalRecHit/interface/HBHERecHit.h"
+#include "DataFormats/HcalRecHit/interface/HORecHit.h"
+#include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
+#include "Geometry/CaloGeometry/interface/CaloCellGeometry.h"
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+
+
+class CaloTableProducer : public edm::global::EDProducer<> {
+public:
+  CaloTableProducer(const edm::ParameterSet& cfg) :
+      hbheToken_(consumes<HBHERecHitCollection>(cfg.getParameter<edm::InputTag>("hbhe"))),
+      hoToken_(consumes<HORecHitCollection>(cfg.getParameter<edm::InputTag>("ho"))),
+      ebToken_(consumes<EcalRecHitCollection>(cfg.getParameter<edm::InputTag>("eb"))),
+      eeToken_(consumes<EcalRecHitCollection>(cfg.getParameter<edm::InputTag>("ee"))),
+      geometryToken_(esConsumes<CaloGeometry, CaloGeometryRecord>()),
+      precision_(cfg.getParameter<int>("precision"))
+  {
+    produces<nanoaod::FlatTable>("RecHitHBHE");
+    produces<nanoaod::FlatTable>("RecHitHO");
+    produces<nanoaod::FlatTable>("RecHitEB");
+    produces<nanoaod::FlatTable>("RecHitEE");
+  }
+
+  void produce(edm::StreamID id, edm::Event& event, const edm::EventSetup& setup) const override
+  {
+    const auto& geometry = setup.getData(geometryToken_);
+
+    FillHBHE(event, geometry);
+    FillHO(event, geometry);
+    FillEcal(event, ebToken_, geometry, "RecHitEB");
+    FillEcal(event, eeToken_, geometry, "RecHitEE");
+  }
+
+  template<typename T, typename F>
+  std::unique_ptr<nanoaod::FlatTable> Fill(const edm::Event& event, const edm::EDGetTokenT<T>& token,
+                                           const CaloGeometry& geometry, const std::string& name, F fn) const
+  {
+    const auto& recHits = event.get(token);
+    std::vector<float> rho, eta, phi, energy, time;
+
+    for(const auto& hit : recHits) {
+      const auto& position = geometry.getGeometry(hit.id())->getPosition();
+      rho.push_back(position.perp());
+      eta.push_back(position.eta());
+      phi.push_back(position.phi());
+      energy.push_back(hit.energy());
+      time.push_back(hit.time());
+      fn(hit);
+    }
+
+    auto table = std::make_unique<nanoaod::FlatTable>(rho.size(), name, false, false);
+    table->addColumn<float>("rho", rho, "rho", precision_);
+    table->addColumn<float>("eta", eta, "eta", precision_);
+    table->addColumn<float>("phi", phi, "phi", precision_);
+    table->addColumn<float>("energy", energy, "energy", precision_);
+    table->addColumn<float>("time", time, "time", precision_);
+
+    return table;
+  }
+
+  void FillHBHE(edm::Event& event, const CaloGeometry& geometry) const
+  {
+    static const std::string name = "RecHitHBHE";
+    std::vector<float> eraw, eaux, rho_front, eta_front, phi_front, chi2, timeFalling;
+    std::vector<bool> isMerged;
+    auto table = Fill(event, hbheToken_, geometry, name, [&](const HBHERecHit& hit) {
+      const auto& positionFront = geometry.getGeometry(hit.idFront())->getPosition();
+      eraw.push_back(hit.eraw());
+      eaux.push_back(hit.eaux());
+      rho_front.push_back(positionFront.perp());
+      eta_front.push_back(positionFront.eta());
+      phi_front.push_back(positionFront.phi());
+      chi2.push_back(hit.chi2());
+      timeFalling.push_back(hit.timeFalling());
+      isMerged.push_back(hit.isMerged());
+    });
+
+    table->addColumn<float>("eraw", eraw, "eraw", precision_);
+    table->addColumn<float>("eaux", eaux, "eaux", precision_);
+    table->addColumn<float>("rho_front", rho_front, "rho_front", precision_);
+    table->addColumn<float>("eta_front", eta_front, "eta_front", precision_);
+    table->addColumn<float>("phi_front", phi_front, "phi_front", precision_);
+    table->addColumn<float>("chi2", chi2, "chi2", precision_);
+    table->addColumn<float>("timeFalling", timeFalling, "timeFalling", precision_);
+    table->addColumn<bool>("isMerged", isMerged, "isMerged", precision_);
+
+    event.put(std::move(table), name);
+  }
+
+  void FillHO(edm::Event& event, const CaloGeometry& geometry) const
+  {
+    static const std::string name = "RecHitHO";
+    auto table = Fill(event, hoToken_, geometry, name, [](const HORecHit&){});
+    event.put(std::move(table), name);
+  }
+
+  void FillEcal(edm::Event& event, const edm::EDGetTokenT<EcalRecHitCollection>& token,
+                const CaloGeometry& geometry, const std::string& name) const
+  {
+    std::vector<float> energyError, timeError, chi2;
+    std::vector<bool> isRecovered, isTimeValid, isTimeErrorValid;
+    auto table = Fill(event, token, geometry, name, [&](const EcalRecHit& hit) {
+      energyError.push_back(hit.energyError());
+      timeError.push_back(hit.timeError());
+      chi2.push_back(hit.chi2());
+      isRecovered.push_back(hit.isRecovered());
+      isTimeValid.push_back(hit.isTimeValid());
+      isTimeErrorValid.push_back(hit.isTimeErrorValid());
+    });
+
+    table->addColumn<float>("energyError", energyError, "energyError", precision_);
+    table->addColumn<float>("timeError", timeError, "timeError", precision_);
+    table->addColumn<float>("chi2", chi2, "chi2", precision_);
+    table->addColumn<bool>("isRecovered", isRecovered, "isRecovered", precision_);
+    table->addColumn<bool>("isTimeValid", isTimeValid, "isTimeValid", precision_);
+    table->addColumn<bool>("isTimeErrorValid", isTimeErrorValid, "isTimeErrorValid", precision_);
+
+    event.put(std::move(table), name);
+  }
+
+private:
+  const edm::EDGetTokenT<HBHERecHitCollection> hbheToken_;
+  const edm::EDGetTokenT<HORecHitCollection> hoToken_;
+  const edm::EDGetTokenT<EcalRecHitCollection> ebToken_;
+  const edm::EDGetTokenT<EcalRecHitCollection> eeToken_;
+  const edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geometryToken_;
+  const unsigned int precision_;
+};
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(CaloTableProducer);

--- a/Production/plugins/L1TableProducer.cc
+++ b/Production/plugins/L1TableProducer.cc
@@ -1,0 +1,125 @@
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/NanoAOD/interface/FlatTable.h"
+#include "DataFormats/L1Trigger/interface/EGamma.h"
+#include "DataFormats/L1Trigger/interface/Tau.h"
+#include "DataFormats/L1Trigger/interface/Jet.h"
+#include "DataFormats/L1Trigger/interface/Muon.h"
+
+class L1TableProducer : public edm::global::EDProducer<> {
+public:
+  L1TableProducer(const edm::ParameterSet& cfg) :
+      egammasToken_(consumes<l1t::EGammaBxCollection>(cfg.getParameter<edm::InputTag>("egammas"))),
+      muonsToken_(consumes<l1t::MuonBxCollection>(cfg.getParameter<edm::InputTag>("muons"))),
+      jetsToken_(consumes<l1t::JetBxCollection>(cfg.getParameter<edm::InputTag>("jets"))),
+      tausToken_(consumes<l1t::TauBxCollection>(cfg.getParameter<edm::InputTag>("taus"))),
+      precision_(cfg.getParameter<int>("precision"))
+  {
+    produces<nanoaod::FlatTable>("L1Egamma");
+    produces<nanoaod::FlatTable>("L1Muon");
+    produces<nanoaod::FlatTable>("L1Jet");
+    produces<nanoaod::FlatTable>("L1Tau");
+  }
+
+  void produce(edm::StreamID id, edm::Event& event, const edm::EventSetup& setup) const override
+  {
+    FillEgammas(event);
+    FillMuons(event);
+    FillJets(event);
+    FillTaus(event);
+  }
+
+  template<typename T, typename F>
+  std::unique_ptr<nanoaod::FlatTable> Fill(edm::Event& event, const edm::EDGetTokenT<T>& token,
+                                           const std::string& name, F fn) const
+  {
+    const auto& collection = event.get(token);
+    std::vector<float> pt, eta, phi;
+    std::vector<int> hwQual;
+
+    for(int bx = collection.getFirstBX(); bx <= collection.getLastBX(); ++bx) {
+      if(bx != 0) continue;
+      for(auto it = collection.begin(bx); it != collection.end(bx); ++it) {
+        if(it->pt() <= 0) continue;
+        pt.push_back(it->pt());
+        eta.push_back(it->eta());
+        phi.push_back(it->phi());
+        hwQual.push_back(it->hwQual());
+        fn(it);
+      }
+    }
+
+    auto table = std::make_unique<nanoaod::FlatTable>(pt.size(), name, false, false);
+    table->addColumn<float>("pt", pt, "transverse momentum", precision_);
+    table->addColumn<float>("eta", eta, "pseudorapidity", precision_);
+    table->addColumn<float>("phi", phi, "azimuthal angle", precision_);
+    table->addColumn<int>("hwQual", hwQual, "hardware quality");
+    return table;
+  }
+
+  void FillEgammas(edm::Event& event) const
+  {
+    static const std::string name = "L1Egamma";
+    std::vector<int> hwIso;
+    auto table = Fill(event, egammasToken_, name, [&](const auto& it) {
+      hwIso.push_back(it->hwIso());
+    });
+    table->addColumn<int>("hwIso", hwIso, "hardware isolation");
+    event.put(std::move(table), name);
+  }
+
+  void FillMuons(edm::Event& event) const
+  {
+    static const std::string name = "L1Muon";
+    std::vector<float> ptUnconstrained;
+    std::vector<int> charge, hwIso, hwDXY;
+    auto table = Fill(event, muonsToken_, name, [&](const auto& it) {
+      ptUnconstrained.push_back(it->ptUnconstrained());
+      charge.push_back(it->charge());
+      hwIso.push_back(it->hwIso());
+      hwDXY.push_back(it->hwDXY());
+    });
+    table->addColumn<float>("ptUnconstrained", ptUnconstrained, "unconstrained transverse momentum", precision_);
+    table->addColumn<int>("charge", charge, "charge");
+    table->addColumn<int>("hwIso", hwIso, "hardware isolation");
+    table->addColumn<int>("hwDXY", hwDXY, "hardware transverse impact parameter");
+    event.put(std::move(table), name);
+  }
+
+  void FillJets(edm::Event& event) const
+  {
+    static const std::string name = "L1Jet";
+    std::vector<int> rawEt, seedEt, puEt;
+    auto table = Fill(event, jetsToken_, name, [&](const auto& it) {
+      rawEt.push_back(it->rawEt());
+      seedEt.push_back(it->seedEt());
+      puEt.push_back(it->puEt());
+    });
+    table->addColumn<int>("rawEt", rawEt, "raw (uncalibrated) cluster sum");
+    table->addColumn<int>("seedEt", seedEt, "transverse energy of the seed");
+    table->addColumn<int>("puEt", puEt, "transverse energy of the pile-up");
+    event.put(std::move(table), name);
+  }
+
+  void FillTaus(edm::Event& event) const
+  {
+    static const std::string name = "L1Tau";
+    std::vector<int> hwIso;
+    auto table = Fill(event, tausToken_, name, [&](const auto& it) {
+      hwIso.push_back(it->hwIso());
+    });
+    table->addColumn<int>("hwIso", hwIso, "hardware isolation");
+    event.put(std::move(table), name);
+  }
+
+private:
+  const edm::EDGetTokenT<l1t::EGammaBxCollection> egammasToken_;
+  const edm::EDGetTokenT<l1t::MuonBxCollection> muonsToken_;
+  const edm::EDGetTokenT<l1t::JetBxCollection> jetsToken_;
+  const edm::EDGetTokenT<l1t::TauBxCollection> tausToken_;
+  const unsigned int precision_;
+};
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(L1TableProducer);

--- a/Production/plugins/L1TableProducer.cc
+++ b/Production/plugins/L1TableProducer.cc
@@ -31,7 +31,7 @@ public:
   }
 
   template<typename T, typename F>
-  std::unique_ptr<nanoaod::FlatTable> Fill(edm::Event& event, const edm::EDGetTokenT<T>& token,
+  std::unique_ptr<nanoaod::FlatTable> Fill(const edm::Event& event, const edm::EDGetTokenT<T>& token,
                                            const std::string& name, F fn) const
   {
     const auto& collection = event.get(token);

--- a/Production/plugins/L1TableProducer.cc
+++ b/Production/plugins/L1TableProducer.cc
@@ -22,6 +22,7 @@ public:
     produces<nanoaod::FlatTable>("L1Tau");
   }
 
+private:
   void produce(edm::StreamID id, edm::Event& event, const edm::EventSetup& setup) const override
   {
     FillEgammas(event);

--- a/Production/plugins/PixelTrackTableProducer.cc
+++ b/Production/plugins/PixelTrackTableProducer.cc
@@ -1,0 +1,192 @@
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/NanoAOD/interface/FlatTable.h"
+
+#include "CUDADataFormats/Track/interface/PixelTrackHeterogeneous.h"
+#include "CUDADataFormats/Track/interface/TrackSoAHeterogeneousT.h"
+#include "CUDADataFormats/Vertex/interface/ZVertexSoA.h"
+#include "CUDADataFormats/Vertex/interface/ZVertexHeterogeneous.h"
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "DataFormats/GeometrySurface/interface/Plane.h"
+#include "DataFormats/Math/interface/Vector3D.h"
+#include "DataFormats/TrajectoryState/interface/LocalTrajectoryParameters.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "RecoPixelVertexing/PixelTrackFitting/interface/FitUtils.h"
+#include "TrackingTools/TrajectoryParametrization/interface/GlobalTrajectoryParameters.h"
+
+class PixelTrackTableProducer : public edm::global::EDProducer<> {
+public:
+  using TrackSoA = pixelTrack::TrackSoA;
+  PixelTrackTableProducer(const edm::ParameterSet& cfg) :
+      tracksToken_(consumes<>(cfg.getParameter<edm::InputTag>("tracks"))),
+      verticesToken_(consumes<ZVertexHeterogeneous>(cfg.getParameter<edm::InputTag>("vertices"))),
+      beamSpotToken_(consumes<reco::BeamSpot>(cfg.getParameter<edm::InputTag>("beamSpot"))),
+      bFieldToken_(esConsumes<MagneticField, IdealMagneticFieldRecord>()),
+      precision_(cfg.getParameter<int>("precision"))
+  {
+    produces<nanoaod::FlatTable>("PixelTrack");
+    produces<nanoaod::FlatTable>("PixelVertex");
+  }
+
+private:
+  void produce(edm::StreamID id, edm::Event& event, const edm::EventSetup& setup) const override
+  {
+    const auto& tracks = *event.get(tracksToken_);
+    const auto& vertices = *event.get(verticesToken_);
+    const auto& beamSpot = event.get(beamSpotToken_);
+    const auto& bField = setup.getData(bFieldToken_);
+
+    const auto [trkGood, vtxGood] = selectGoodTracksAndVertices(tracks, vertices);
+
+    FillTracks(event, tracks, vertices, beamSpot, bField, trkGood, vtxGood);
+    FillVertices(event, vertices, vtxGood);
+  }
+
+  void FillTracks(edm::Event& event, const TrackSoA& tracks, const ZVertexSoA& vertices,
+                  const reco::BeamSpot& beamSpot, const MagneticField& bField,
+                  const std::vector<int>& trkGood, const std::vector<int>& vtxGood) const
+  {
+    static const std::string name = "PixelTrack";
+    const size_t nTrk = trkGood.size();
+    std::vector<float> pt(nTrk), eta(nTrk), phi(nTrk), tip(nTrk), zip(nTrk), chi2(nTrk), charge(nTrk),
+                       dxy(nTrk), dz(nTrk);
+    std::vector<int> quality(nTrk), nLayers(nTrk), nHits(nTrk), vtxIdx(nTrk);
+
+    for(size_t trk_outIdx = 0; trk_outIdx < nTrk; ++trk_outIdx) {
+      const int trk_idx = trkGood[trk_outIdx];
+      pt[trk_outIdx] = tracks.pt(trk_idx);
+      eta[trk_outIdx] = tracks.eta(trk_idx);
+      phi[trk_outIdx] = tracks.phi(trk_idx);
+      tip[trk_outIdx] = tracks.tip(trk_idx);
+      zip[trk_outIdx] = tracks.zip(trk_idx);
+      chi2[trk_outIdx] = tracks.chi2(trk_idx);
+      charge[trk_outIdx] = tracks.charge(trk_idx);
+      quality[trk_outIdx] = static_cast<int>(tracks.quality(trk_idx));
+      nLayers[trk_outIdx] = tracks.nLayers(trk_idx);
+      nHits[trk_outIdx] = tracks.nHits(trk_idx);
+
+      const auto [trk_dxy, trk_dz] = computeImpactParameters(tracks, trk_idx, beamSpot, bField);
+      dxy[trk_outIdx] = trk_dxy;
+      dz[trk_outIdx] = trk_dz;
+
+      const int vtx_idx = vertices.idv[trk_idx];
+      auto iter = std::find(vtxGood.begin(), vtxGood.end(), vtx_idx);
+      int vtx_outIdx = -1;
+      if(iter != vtxGood.end())
+        vtx_outIdx = std::distance(vtxGood.begin(), iter);
+      vtxIdx[trk_outIdx] = vtx_outIdx;
+    }
+
+    auto table = std::make_unique<nanoaod::FlatTable>(nTrk, name, false, false);
+    table->addColumn<float>("pt", pt, "pt", precision_);
+    table->addColumn<float>("eta", eta, "eta", precision_);
+    table->addColumn<float>("phi", phi, "phi", precision_);
+    table->addColumn<float>("tip", tip, "tip", precision_);
+    table->addColumn<float>("zip", zip, "zip", precision_);
+    table->addColumn<float>("chi2", chi2, "chi2", precision_);
+    table->addColumn<float>("charge", charge, "charge", precision_);
+    table->addColumn<int>("quality", quality,
+      "track quality: bad = 0, edup = 1, dup = 2, loose = 3, strict = 4, tight = 5, highPurity = 6");
+    table->addColumn<int>("nLayers", nLayers, "number of layers with hits");
+    table->addColumn<int>("nHits", nHits, "number of hits");
+    table->addColumn<float>("dxy", dxy, "transverse IP wrt the beam spot", precision_);
+    table->addColumn<float>("dz", dz, "longitudinal IP wrt the beam spot", precision_);
+    table->addColumn<int>("vtxIdx", vtxIdx, "index of the associated vertex (-1 if none)");
+
+    event.put(std::move(table), name);
+  }
+
+  void FillVertices(edm::Event& event, const ZVertexSoA& vertices, const std::vector<int>& vtxGood) const
+  {
+    static const std::string name = "PixelVertex";
+    const size_t nVtx = vtxGood.size();
+
+    std::vector<float> zv(nVtx), wv(nVtx), chi2(nVtx), ptv2(nVtx);
+    std::vector<int> ndof(nVtx);
+
+    for(size_t vtx_outIdx = 0; vtx_outIdx < nVtx; ++vtx_outIdx) {
+      const int vtx_idx = vtxGood[vtx_outIdx];
+      zv[vtx_outIdx] = vertices.zv[vtx_idx];
+      wv[vtx_outIdx] = vertices.wv[vtx_idx];
+      chi2[vtx_outIdx] = vertices.chi2[vtx_idx];
+      ptv2[vtx_outIdx] = vertices.ptv2[vtx_idx];
+      ndof[vtx_outIdx] = vertices.ndof[vtx_idx];
+    }
+
+    auto table = std::make_unique<nanoaod::FlatTable>(nVtx, name, false, false);
+    table->addColumn<float>("z", zv, "z-position", precision_);
+    table->addColumn<float>("weight", wv, "weight (1/error^2)", precision_);
+    table->addColumn<float>("chi2", chi2, "chi2", precision_);
+    table->addColumn<float>("ptv2", ptv2, "pt^2", precision_);
+    table->addColumn<int>("ndof", ndof, "number of degrees of freedom");
+
+    event.put(std::move(table), name);
+  }
+
+  std::pair<std::vector<int>, std::vector<int>> selectGoodTracksAndVertices(const TrackSoA& tracks,
+                                                                            const ZVertexSoA& vertices) const
+  {
+    const uint32_t nv = vertices.nvFinal;
+    std::vector<int> trkGood, vtxGood;
+
+    std::vector<size_t> nTrkAssociated(nv, 0);
+    for(int32_t trk_idx = 0; trk_idx < tracks.stride(); ++trk_idx) {
+      const auto nHits = tracks.nHits(trk_idx);
+      if(nHits == 0) break;
+      if(nHits > 0 && tracks.quality(trk_idx) >= pixelTrack::Quality::loose) {
+        trkGood.push_back(trk_idx);
+        const int16_t vtx_idx = vertices.idv[trk_idx];
+        if(vtx_idx >= 0 && vtx_idx < static_cast<int16_t>(nv))
+          ++nTrkAssociated[vtx_idx];
+      }
+    }
+    for (int j = nv - 1; j >= 0; --j) {
+      const uint16_t vtx_idx = vertices.sortInd[j];
+      assert(vtx_idx < nv);
+      if (nTrkAssociated[vtx_idx] >= 2) {
+        vtxGood.push_back(vtx_idx);
+      }
+    }
+    return std::make_pair(std::move(trkGood), std::move(vtxGood));
+  }
+
+  std::pair<float, float> computeImpactParameters(const TrackSoA& tracks, int trk_idx,
+                                                  const reco::BeamSpot& beamspot, const MagneticField& magfi) const
+  {
+    riemannFit::Vector5d ipar, opar;
+    riemannFit::Matrix5d icov, ocov;
+    tracks.stateAtBS.copyToDense(ipar, icov, trk_idx);
+    riemannFit::transformToPerigeePlane(ipar, icov, opar, ocov);
+    const LocalTrajectoryParameters lpar(opar(0), opar(1), opar(2), opar(3), opar(4), 1.);
+    const float sp = std::sin(tracks.phi(trk_idx));
+    const float cp = std::cos(tracks.phi(trk_idx));
+    const Surface::RotationType rotation(sp, -cp, 0, 0, 0, -1.f, cp, sp, 0);
+    const GlobalPoint beamSpotPoint(beamspot.x0(), beamspot.y0(), beamspot.z0());
+    const Plane impPointPlane(beamSpotPoint, rotation);
+    const GlobalTrajectoryParameters gp(impPointPlane.toGlobal(lpar.position()),
+                                        impPointPlane.toGlobal(lpar.momentum()), lpar.charge(), &magfi);
+    const GlobalPoint vv = gp.position();
+    const math::XYZPoint pos(vv.x(), vv.y(), vv.z());
+    const GlobalVector pp = gp.momentum();
+    const math::XYZVector mom(pp.x(), pp.y(), pp.z());
+    const auto lambda = M_PI_2 - pp.theta();
+    const auto phi = pp.phi();
+    const float dxy = -vv.x() * std::sin(phi) + vv.y() * std::cos(phi);
+    const float dz =
+        (vv.z() * std::cos(lambda) - (vv.x() * std::cos(phi) + vv.y() * std::sin(phi)) * std::sin(lambda)) /
+        std::cos(lambda);
+    return std::make_pair(dxy, dz);
+  }
+
+private:
+  const edm::EDGetTokenT<PixelTrackHeterogeneous> tracksToken_;
+  const edm::EDGetTokenT<ZVertexHeterogeneous> verticesToken_;
+  const edm::EDGetTokenT<reco::BeamSpot> beamSpotToken_;
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> bFieldToken_;
+  const unsigned int precision_;
+};
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(PixelTrackTableProducer);

--- a/Production/plugins/TauTableProducerHLT.cc
+++ b/Production/plugins/TauTableProducerHLT.cc
@@ -51,7 +51,7 @@ public:
     std::vector<float> secondaryVertex_y(tausIP.size());
     std::vector<float> secondaryVertex_z(tausIP.size());
     std::vector<float> secondaryVertex_t(tausIP.size());
-    
+
     // for (size_t tau_index = 0; tau_index < tauScore.size(); tau_index++) {
     //   scores[tau_index] = tauScore.ValueMap(TauCollection.at(tau_index));.output_desc;
     // }
@@ -81,9 +81,9 @@ public:
         secondaryVertex_y[tau_index] = -999.;
         secondaryVertex_z[tau_index] = -999.;
       };
-      
+
       // secondaryVertex_t[tau_index] = tausIP.value(tau_index)->secondaryVertex().t();
-      
+
     }
 
     auto tauTable = std::make_unique<nanoaod::FlatTable>(tausIP.size(), "Tau", false, true);

--- a/Production/plugins/TauTableProducerHLT.cc
+++ b/Production/plugins/TauTableProducerHLT.cc
@@ -23,6 +23,7 @@ public:
     produces<nanoaod::FlatTable>("Tau");
   }
 
+private:
   void produce(edm::StreamID id, edm::Event& event, const edm::EventSetup& setup) const override
   {
     const auto tausHandle = event.getHandle(tauToken_);

--- a/Production/python/customiseHLT.py
+++ b/Production/python/customiseHLT.py
@@ -278,6 +278,14 @@ def customise(process):
     precision = cms.int32(7)
   )
 
+  process.caloTable = cms.EDProducer("CaloTableProducer",
+    hbhe = cms.InputTag("hltHbhereco"),
+    ho = cms.InputTag("hltHoreco"),
+    eb = cms.InputTag("hltEcalRecHit", "EcalRecHitsEB"),
+    ee = cms.InputTag("hltEcalRecHit", "EcalRecHitsEE"),
+    precision = cms.int32(7)
+  )
+
   process.tauTablesTask = cms.Task(process.tauTable, process.tauExtTable)
   process.pfCandTablesTask = cms.Task(process.pfCandTable)
   process.AK4PFJetsTableTask = cms.Task(process.AK4PFJetsTable)
@@ -286,6 +294,7 @@ def customise(process):
   process.recoAllGenJetsNoNuTask=cms.Task(process.ak4GenJetsNoNu)
   process.GenJetTableTask = cms.Task(process.GenJetTable, process.ak4GenJetsNoNuExtTable)
   process.L1TableTask = cms.Task(process.L1Table)
+  process.caloTableTask = cms.Task(process.caloTable)
   process.nanoTableTaskFS = cms.Task(process.genParticleTablesTask,
                                      process.genParticleTask,
                                      process.tauTablesTask,
@@ -295,7 +304,8 @@ def customise(process):
                                      process.AK4PFJetsTableTask,
                                      process.recoAllGenJetsNoNuTask,
                                      process.GenJetTableTask,
-                                     process.L1TableTask)
+                                     process.L1TableTask,
+                                     process.caloTableTask)
   process.nanoSequenceMC = cms.Sequence(process.nanoTableTaskFS)
   process.finalGenParticles.src = cms.InputTag("genParticles")
 

--- a/Production/python/customiseHLT.py
+++ b/Production/python/customiseHLT.py
@@ -56,7 +56,7 @@ def customise(process):
   process.load('PhysicsTools.NanoAOD.nano_cff')
   process.load('RecoJets.JetProducers.ak4GenJets_cfi')
   from PhysicsTools.NanoAOD.nano_cff import nanoAOD_customizeMC
-  from RecoJets.JetProducers.ak4GenJets_cfi import ak4GenJets 
+  from RecoJets.JetProducers.ak4GenJets_cfi import ak4GenJets
   #call to customisation function nanoAOD_customizeMC imported from PhysicsTools.NanoAOD.nano_cff
   process = nanoAOD_customizeMC(process)
 
@@ -66,17 +66,17 @@ def customise(process):
     + process.HLTHPSDeepTauPFTauSequenceForVBFIsoTau \
     + process.nanoSequenceMC)
   process.NANOAODSIMoutput_step = cms.EndPath(process.NANOAODSIMoutput)
-  
+
   from PhysicsTools.JetMCAlgos.HadronAndPartonSelector_cfi import selectedHadronsAndPartons
   process.selectedHadronsAndPartons = selectedHadronsAndPartons.clone(src = cms.InputTag("genParticlesForJetsNoNu"))
-  # set ak4GenJets producer 
+  # set ak4GenJets producer
   process.ak4GenJetsNoNu = ak4GenJets.clone( src = "genParticlesForJetsNoNu")
-  process.genJetFlavourInfos = ak4JetFlavourInfos.clone(  
+  process.genJetFlavourInfos = ak4JetFlavourInfos.clone(
     jets = cms.InputTag( "ak4GenJetsNoNu" ),
-    bHadrons= cms.InputTag("selectedHadronsAndPartons","bHadrons"), 
+    bHadrons= cms.InputTag("selectedHadronsAndPartons","bHadrons"),
     cHadrons= cms.InputTag("selectedHadronsAndPartons","cHadrons"),
     partons= cms.InputTag("selectedHadronsAndPartons","physicsPartons"), )
-  
+
   process.load('RecoJets.Configuration.GenJetParticles_cff')
 
   process.GenJetTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
@@ -188,7 +188,7 @@ def customise(process):
       status = Var("status", int, doc='status word'),
       longLived = Var("longLived", bool, doc='is long lived?'),
       massConstraint = Var("massConstraint", bool, doc='do mass constraint?'),
-      # source: cmssw/PhysicsTools/NanoAOD/plugins/SimpleFlatTableProducerPlugins.cc 
+      # source: cmssw/PhysicsTools/NanoAOD/plugins/SimpleFlatTableProducerPlugins.cc
       trackDz = Var("? trackRef.isNonnull && trackRef.isAvailable ? trackRef.dz : -999.", float, doc = "track Dz"),
       trackDxy = Var("? trackRef.isNonnull && trackRef.isAvailable ? trackRef.dxy : -999.", float, doc = "track Dxy"),
       trackIsValid = Var("trackRef.isNonnull && trackRef.isAvailable", bool, doc = "track is valid"),
@@ -270,7 +270,14 @@ def customise(process):
     )
   )
 
-      
+  process.L1Table = cms.EDProducer("L1TableProducer",
+    egammas = cms.InputTag("hltGtStage2Digis", "EGamma"),
+    muons = cms.InputTag("hltGtStage2Digis", "Muon"),
+    jets = cms.InputTag("hltGtStage2Digis", "Jet"),
+    taus = cms.InputTag("hltGtStage2Digis", "Tau"),
+    precision = cms.int32(7)
+  )
+
   process.tauTablesTask = cms.Task(process.tauTable, process.tauExtTable)
   process.pfCandTablesTask = cms.Task(process.pfCandTable)
   process.AK4PFJetsTableTask = cms.Task(process.AK4PFJetsTable)
@@ -278,9 +285,17 @@ def customise(process):
   process.genJetFlavourInfosTask =  cms.Task(process.genJetFlavourInfos)
   process.recoAllGenJetsNoNuTask=cms.Task(process.ak4GenJetsNoNu)
   process.GenJetTableTask = cms.Task(process.GenJetTable, process.ak4GenJetsNoNuExtTable)
-  process.nanoTableTaskFS = cms.Task(process.genParticleTablesTask, process.genParticleTask,
-                                     process.tauTablesTask, process.pfCandTablesTask, process.genParticlesForJetsNoNuTask, process.genJetFlavourInfosTask,
-                                     process.AK4PFJetsTableTask, process.recoAllGenJetsNoNuTask,process.GenJetTableTask)#,  )
+  process.L1TableTask = cms.Task(process.L1Table)
+  process.nanoTableTaskFS = cms.Task(process.genParticleTablesTask,
+                                     process.genParticleTask,
+                                     process.tauTablesTask,
+                                     process.pfCandTablesTask,
+                                     process.genParticlesForJetsNoNuTask,
+                                     process.genJetFlavourInfosTask,
+                                     process.AK4PFJetsTableTask,
+                                     process.recoAllGenJetsNoNuTask,
+                                     process.GenJetTableTask,
+                                     process.L1TableTask)
   process.nanoSequenceMC = cms.Sequence(process.nanoTableTaskFS)
   process.finalGenParticles.src = cms.InputTag("genParticles")
 
@@ -302,7 +317,7 @@ def customise(process):
   del process.MessageLogger.HLTrigReport
   del process.MessageLogger.FastReport
   del process.MessageLogger.ThroughputService
-
+  process.MessageLogger.cerr.enableStatistics = cms.untracked.bool(False)
 
   process.options.wantSummary = False
 

--- a/Production/python/customiseHLT.py
+++ b/Production/python/customiseHLT.py
@@ -286,6 +286,13 @@ def customise(process):
     precision = cms.int32(7)
   )
 
+  process.pixelTrackTable = cms.EDProducer("PixelTrackTableProducer",
+    tracks = cms.InputTag("hltPixelTracksSoA"),
+    vertices = cms.InputTag("hltPixelVerticesSoA"),
+    beamSpot = cms.InputTag("hltOnlineBeamSpot"),
+    precision = cms.int32(7)
+  )
+
   process.tauTablesTask = cms.Task(process.tauTable, process.tauExtTable)
   process.pfCandTablesTask = cms.Task(process.pfCandTable)
   process.AK4PFJetsTableTask = cms.Task(process.AK4PFJetsTable)
@@ -295,6 +302,7 @@ def customise(process):
   process.GenJetTableTask = cms.Task(process.GenJetTable, process.ak4GenJetsNoNuExtTable)
   process.L1TableTask = cms.Task(process.L1Table)
   process.caloTableTask = cms.Task(process.caloTable)
+  process.pixelTrackTableTask = cms.Task(process.pixelTrackTable)
   process.nanoTableTaskFS = cms.Task(process.genParticleTablesTask,
                                      process.genParticleTask,
                                      process.tauTablesTask,
@@ -305,7 +313,8 @@ def customise(process):
                                      process.recoAllGenJetsNoNuTask,
                                      process.GenJetTableTask,
                                      process.L1TableTask,
-                                     process.caloTableTask)
+                                     process.caloTableTask,
+                                     process.pixelTrackTableTask)
   process.nanoSequenceMC = cms.Sequence(process.nanoTableTaskFS)
   process.finalGenParticles.src = cms.InputTag("genParticles")
 
@@ -328,6 +337,7 @@ def customise(process):
   del process.MessageLogger.FastReport
   del process.MessageLogger.ThroughputService
   process.MessageLogger.cerr.enableStatistics = cms.untracked.bool(False)
+  del process.dqmOutput
 
   process.options.wantSummary = False
 


### PR DESCRIPTION
Added tables:
- calo RecHits for HB, HE, HO, EB and EE
- L1 objects: electrons, muons, taus and jets
- Pixel tracks and pixel vertices

Fixed linking issue introduced in the previous PR.