### PR TITLE
Added possibility to use regexp in Smart Trees

### DIFF
--- a/Production/plugins/TauTupleProducer.cc
+++ b/Production/plugins/TauTupleProducer.cc
@@ -69,15 +69,15 @@ struct TauTupleProducerData {
     std::unique_ptr<tau_tuple::TauTuple> tauTuple;
     std::unique_ptr<tau_tuple::SummaryTuple> summaryTuple;
 
-    TauTupleProducerData(const std::vector<std::string>& disableBranches) :
+    TauTupleProducerData(const std::vector<std::string>& disabledBranches, const std::vector<std::string>& enabledBranches) :
         start(clock::now())
     {
         TFile& file = edm::Service<TFileService>()->file();
         file.SetCompressionAlgorithm(ROOT::kLZMA);
         file.SetCompressionLevel(9);
         tauTuple = std::make_unique<tau_tuple::TauTuple>("taus", &file, false,
-            std::set<std::string>(disableBranches.begin(), disableBranches.end()),
-            std::set<std::string>()
+            std::set<std::string>(disabledBranches.begin(), disabledBranches.end()),
+            std::set<std::string>(enabledBranches.begin(), enabledBranches.end())
             );
         summaryTuple = std::make_unique<tau_tuple::SummaryTuple>("summary", &file, false);
         (*summaryTuple)().numberOfProcessedEvents = 0;
@@ -103,7 +103,8 @@ public:
         requireGenMatch(cfg.getParameter<bool>("requireGenMatch")),
         requireGenORRecoTauMatch(cfg.getParameter<bool>("requireGenORRecoTauMatch")),
         applyRecoPtSieve(cfg.getParameter<bool>("applyRecoPtSieve")),
-        disableBranches(cfg.getParameter<std::vector<std::string>>("disableBranches")),
+        disabledBranches(cfg.getParameter<std::vector<std::string>>("disabledBranches")),
+        enabledBranches(cfg.getParameter<std::vector<std::string>>("enabledBranches")),
         genEvent_token(mayConsume<GenEventInfoProduct>(cfg.getParameter<edm::InputTag>("genEvent"))),
         genParticles_token(mayConsume<reco::GenParticleCollection>(cfg.getParameter<edm::InputTag>("genParticles"))),
         genJets_token(mayConsume<reco::GenJetCollection>(cfg.getParameter<edm::InputTag>("genJets"))),
@@ -132,7 +133,7 @@ public:
         tauSpinnerWTEven_token(mayConsume<double>(cfg.getParameter<edm::InputTag>("tauSpinnerWTEven"))),
         tauSpinnerWTOdd_token(mayConsume<double>(cfg.getParameter<edm::InputTag>("tauSpinnerWTOdd"))),
         tauSpinnerWTMM_token(mayConsume<double>(cfg.getParameter<edm::InputTag>("tauSpinnerWTMM"))),
-        data(disableBranches),
+        data(disabledBranches, enabledBranches),
         tauTuple(*data.tauTuple),
         summaryTuple(*data.summaryTuple),
         selector(selectors::TauJetSelector::Make(cfg.getParameter<std::string>("selector")))
@@ -1044,7 +1045,7 @@ private:
 
 private:
     const bool isMC, isEmbedded, requireGenMatch, requireGenORRecoTauMatch, applyRecoPtSieve;
-    const std::vector<std::string> disableBranches;
+    const std::vector<std::string> disabledBranches, enabledBranches;
     TauJetBuilderSetup builderSetup;
 
     edm::EDGetTokenT<GenEventInfoProduct> genEvent_token;

--- a/Production/python/Production.py
+++ b/Production/python/Production.py
@@ -32,8 +32,10 @@ options.register('selector', 'None', VarParsing.multiplicity.singleton, VarParsi
                  "Name of the tauJet selector.")
 options.register('triggers', '', VarParsing.multiplicity.singleton, VarParsing.varType.string,
                  "Store only events that pass the specified HLT paths.")
-options.register("disableBranches", [], VarParsing.multiplicity.list, VarParsing.varType.string,
+options.register("disabledBranches", [], VarParsing.multiplicity.list, VarParsing.varType.string,
                  "Not store following branches in tupleOutput file.")
+options.register("enabledBranches", [], VarParsing.multiplicity.list, VarParsing.varType.string,
+                 "Branches to store in tupleOutput file (if empty list: stores all the branches).")
 options.register('storeJetsWithoutTau', False, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
                  "Store jets that don't match to any pat::Tau.")
 options.register('requireGenMatch', True, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
@@ -202,7 +204,8 @@ process.tauTupleProducer = cms.EDAnalyzer('TauTupleProducer',
     requireGenMatch          = cms.bool(options.requireGenMatch),
     requireGenORRecoTauMatch = cms.bool(options.requireGenORRecoTauMatch),
     applyRecoPtSieve         = cms.bool(options.applyRecoPtSieve),
-    disableBranches          = cms.vstring(options.disableBranches),
+    disabledBranches         = cms.vstring(options.disabledBranches),
+    enabledBranches          = cms.vstring(options.enabledBranches),
     tauJetBuilderSetup       = tauJetBuilderSetup,
     selector		     = cms.string(options.selector),
 

--- a/Production/python/Production.py
+++ b/Production/python/Production.py
@@ -32,6 +32,8 @@ options.register('selector', 'None', VarParsing.multiplicity.singleton, VarParsi
                  "Name of the tauJet selector.")
 options.register('triggers', '', VarParsing.multiplicity.singleton, VarParsing.varType.string,
                  "Store only events that pass the specified HLT paths.")
+options.register("disableBranches", [], VarParsing.multiplicity.list, VarParsing.varType.string,
+                 "Not store following branches in tupleOutput file.")
 options.register('storeJetsWithoutTau', False, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
                  "Store jets that don't match to any pat::Tau.")
 options.register('requireGenMatch', True, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
@@ -200,6 +202,7 @@ process.tauTupleProducer = cms.EDAnalyzer('TauTupleProducer',
     requireGenMatch          = cms.bool(options.requireGenMatch),
     requireGenORRecoTauMatch = cms.bool(options.requireGenORRecoTauMatch),
     applyRecoPtSieve         = cms.bool(options.applyRecoPtSieve),
+    disableBranches          = cms.vstring(options.disableBranches),
     tauJetBuilderSetup       = tauJetBuilderSetup,
     selector		     = cms.string(options.selector),
 


### PR DESCRIPTION
Hi all,

in this PR I am trying to add some functionality for disabling branches on the production step (needed to preserve the space for displaced tau study when only pfCands are needed), but also might be useful for other studies where only a small part of the variable list in TauTuple.h is required. I am trying to add modifications in two steps:

1) Possibility to use regular expression for enabling and disabling the branches. Now, in addition to exact matching e.g: “tau_pt” regular expressions are allowed, like: “boostedTau_.*”, matching is performed with std::regex_match, so it attempts to match a regular expression to an entire character sequence (branch name) what should prevent the situations where e.g: “tau_pt” would match “tau_pt_weighted_deta_strip” and e.t.c

2) Just disabling tree linkage but leaving declaration of these variables for the writing mode does not work. Because, in the `get` method that is extensively used in tuple production it uses SmartTreeEntryMap of string to the tau tuple variable [object](https://github.com/cms-tau-pog/TauMLTools/blob/7368a01775f894cc9b3e1770e49417c2ab2dac9d/Core/interface/SmartTree.h#L390-L395) in this way `get` method is more safe than `tauTuple().branch_name` since it throw an error on excess request when variable is not linked. However, it does not allow me to use the same TauTupleProducer.cc. The easiest solution would be to add also disabled branches to [`SmartTreeEntryMap entries`](https://github.com/cms-tau-pog/TauMLTools/blob/9342a995dcd05dd1ab62483d6580a804ad280507/Core/interface/SmartTree.h#L336) since it is not  really used anywhere except `get`, however it reduces some safety. Would such compromise be acceptable?