### PR TITLE
Fix ReReco at MiniAOD, added TauJetTag selector (Displaced) 

### DIFF
--- a/Production/interface/Selectors.h
+++ b/Production/interface/Selectors.h
@@ -52,5 +52,13 @@ struct genTauTau : TauJetSelector {
                           const edm::TriggerResults& triggerResults, float rho) override;
 };
 
+struct TauJetTag : TauJetSelector {
+    virtual Result Select(const edm::Event& event, const std::deque<TauJet>& tauJets,
+                          const std::vector<pat::Electron>& electrons,
+                          const std::vector<pat::Muon>& muons, const pat::MET& met,
+                          const reco::Vertex& primaryVertex,
+                          const pat::TriggerObjectStandAloneCollection& triggerObjects,
+                          const edm::TriggerResults& triggerResults, float rho) override;
+};
 } // namespace selectors
 } // namespace tau_analysis

--- a/Production/python/Production.py
+++ b/Production/python/Production.py
@@ -134,7 +134,7 @@ tau_collection = 'slimmedTaus'
 if options.rerunTauReco:
     tau_collection = 'selectedPatTaus'
 
-    tauAtMiniConfig = importlib.import_module('RecoTauTag.Configuration.tools.adaptToRunAtMiniAOD')
+    import RecoTauTag.Configuration.tools.adaptToRunAtMiniAOD as tauAtMiniConfig
     tauAtMiniTools = tauAtMiniConfig.adaptToRunAtMiniAOD(process, runBoosted=False)
     tauAtMiniTools.addTauReReco()
     tauAtMiniTools.adaptTauToMiniAODReReco(reclusterJets = options.reclusterJets)

--- a/Production/python/setupTauReReco.py
+++ b/Production/python/setupTauReReco.py
@@ -19,32 +19,10 @@ def reReco_DisTau(process):
     # https://indico.cern.ch/event/868576/contributions/3696661/attachments/1979084/3295013/tau_displaced_ll_ws_31_1_2020.pdf
 
     process.selectedPatTaus.cut = cms.string('pt > 18.')   ## remove DMFinding filter (was pt > 18. && tauID(\'decayModeFindingNewDMs\')> 0.5)
-
-    process.combinatoricRecoTaus.builders[0].qualityCuts.signalQualityCuts.maxDeltaZ = cms.double(100.)
-    process.combinatoricRecoTaus.builders[0].qualityCuts.signalQualityCuts.maxTrackChi2 = cms.double(1000.)
-    process.combinatoricRecoTaus.builders[0].qualityCuts.signalQualityCuts.maxTransverseImpactParameter = cms.double(100.)
-    process.combinatoricRecoTaus.builders[0].qualityCuts.vxAssocQualityCuts.maxTransverseImpactParameter = cms.double(100.)
-    process.combinatoricRecoTaus.builders[0].qualityCuts.pvFindingAlgo = cms.string('highestPtInEvent')
-
-    # chargedPFCandidates from PFChargedHadrons ... well this is obvious
-    process.ak4PFJetsRecoTauChargedHadrons.builders[0].qualityCuts.signalQualityCuts.maxDeltaZ = cms.double(100.)
-    process.ak4PFJetsRecoTauChargedHadrons.builders[0].qualityCuts.signalQualityCuts.maxTrackChi2 = cms.double(1000.)
-    process.ak4PFJetsRecoTauChargedHadrons.builders[0].qualityCuts.signalQualityCuts.maxTransverseImpactParameter = cms.double(100.)
-    process.ak4PFJetsRecoTauChargedHadrons.builders[0].qualityCuts.vxAssocQualityCuts.maxTransverseImpactParameter = cms.double(100.)
-    process.ak4PFJetsRecoTauChargedHadrons.builders[0].qualityCuts.pvFindingAlgo = cms.string('highestPtInEvent') # closest in dz makes no sense for displaced stuff
-
-    # chargedPFCandidates from lostTracks ... this collections exists in miniAODs
-    # the aim is to use as many track candidates as possible to build taus
-    # in order to maximise the efficiency
-    process.ak4PFJetsRecoTauChargedHadrons.builders[1].qualityCuts.signalQualityCuts.maxDeltaZ = cms.double(100.)
-    process.ak4PFJetsRecoTauChargedHadrons.builders[1].qualityCuts.signalQualityCuts.maxTrackChi2 = cms.double(1000.)
-    process.ak4PFJetsRecoTauChargedHadrons.builders[1].qualityCuts.signalQualityCuts.maxTransverseImpactParameter = cms.double(100.)
-    process.ak4PFJetsRecoTauChargedHadrons.builders[1].qualityCuts.vxAssocQualityCuts.maxTransverseImpactParameter = cms.double(100.)
-    process.ak4PFJetsRecoTauChargedHadrons.builders[1].qualityCuts.pvFindingAlgo = cms.string('highestPtInEvent')
-
-    # chargedPFCandidates from PFNeutralHadrons ... yes, from neutrals too, nothing is thrown away
-    process.ak4PFJetsRecoTauChargedHadrons.builders[2].qualityCuts.signalQualityCuts.maxDeltaZ = cms.double(100.)
-    process.ak4PFJetsRecoTauChargedHadrons.builders[2].qualityCuts.signalQualityCuts.maxTrackChi2 = cms.double(1000.)
-    process.ak4PFJetsRecoTauChargedHadrons.builders[2].qualityCuts.signalQualityCuts.maxTransverseImpactParameter = cms.double(100.)
-    process.ak4PFJetsRecoTauChargedHadrons.builders[2].qualityCuts.vxAssocQualityCuts.maxTransverseImpactParameter = cms.double(100.)
-    process.ak4PFJetsRecoTauChargedHadrons.builders[2].qualityCuts.pvFindingAlgo = cms.string('highestPtInEvent')
+    for builder in process.combinatoricRecoTaus.builders \
+                 + process.ak4PFJetsRecoTauChargedHadrons.builders:
+        builder.qualityCuts.signalQualityCuts.maxDeltaZ = cms.double(100.)
+        builder.qualityCuts.signalQualityCuts.maxTrackChi2 = cms.double(1000.)
+        builder.qualityCuts.signalQualityCuts.maxTransverseImpactParameter = cms.double(100.)
+        builder.qualityCuts.vxAssocQualityCuts.maxTransverseImpactParameter = cms.double(100.)
+        builder.qualityCuts.pvFindingAlgo = cms.string('highestPtInEvent')

--- a/Production/python/setupTauReReco.py
+++ b/Production/python/setupTauReReco.py
@@ -1,0 +1,50 @@
+import FWCore.ParameterSet.Config as cms
+
+# Customization of Tau ReReco at MiniAOD is introduced in this file.
+# Current customization is added after initialization of 
+# cmssw/RecoTauTag/Configuration/python/tools/adaptToRunAtMiniAOD.py
+
+# Available options:
+#   - Custom signal cone reconstruction
+#   - Displaced tau reconstruction
+
+def reReco_SigCone(process):
+    
+    process.combinatoricRecoTaus.builders[0].signalConeSize = cms.string('max(min(0.2, 4.528/(pt()^0.8982)), 0.03)') ## change to quantile 0.95
+    process.selectedPatTaus.cut = cms.string('pt > 18.')   ## remove DMFinding filter (was pt > 18. && tauID(\'decayModeFindingNewDMs\')> 0.5)
+
+def reReco_DisTau(process):
+
+    # The following study is considered as a starting point for modifications:
+    # https://indico.cern.ch/event/868576/contributions/3696661/attachments/1979084/3295013/tau_displaced_ll_ws_31_1_2020.pdf
+
+    process.selectedPatTaus.cut = cms.string('pt > 18.')   ## remove DMFinding filter (was pt > 18. && tauID(\'decayModeFindingNewDMs\')> 0.5)
+
+    process.combinatoricRecoTaus.builders[0].qualityCuts.signalQualityCuts.maxDeltaZ = cms.double(100.)
+    process.combinatoricRecoTaus.builders[0].qualityCuts.signalQualityCuts.maxTrackChi2 = cms.double(1000.)
+    process.combinatoricRecoTaus.builders[0].qualityCuts.signalQualityCuts.maxTransverseImpactParameter = cms.double(100.)
+    process.combinatoricRecoTaus.builders[0].qualityCuts.vxAssocQualityCuts.maxTransverseImpactParameter = cms.double(100.)
+    process.combinatoricRecoTaus.builders[0].qualityCuts.pvFindingAlgo = cms.string('highestPtInEvent')
+
+    # chargedPFCandidates from PFChargedHadrons ... well this is obvious
+    process.ak4PFJetsRecoTauChargedHadrons.builders[0].qualityCuts.signalQualityCuts.maxDeltaZ = cms.double(100.)
+    process.ak4PFJetsRecoTauChargedHadrons.builders[0].qualityCuts.signalQualityCuts.maxTrackChi2 = cms.double(1000.)
+    process.ak4PFJetsRecoTauChargedHadrons.builders[0].qualityCuts.signalQualityCuts.maxTransverseImpactParameter = cms.double(100.)
+    process.ak4PFJetsRecoTauChargedHadrons.builders[0].qualityCuts.vxAssocQualityCuts.maxTransverseImpactParameter = cms.double(100.)
+    process.ak4PFJetsRecoTauChargedHadrons.builders[0].qualityCuts.pvFindingAlgo = cms.string('highestPtInEvent') # closest in dz makes no sense for displaced stuff
+
+    # chargedPFCandidates from lostTracks ... this collections exists in miniAODs
+    # the aim is to use as many track candidates as possible to build taus
+    # in order to maximise the efficiency
+    process.ak4PFJetsRecoTauChargedHadrons.builders[1].qualityCuts.signalQualityCuts.maxDeltaZ = cms.double(100.)
+    process.ak4PFJetsRecoTauChargedHadrons.builders[1].qualityCuts.signalQualityCuts.maxTrackChi2 = cms.double(1000.)
+    process.ak4PFJetsRecoTauChargedHadrons.builders[1].qualityCuts.signalQualityCuts.maxTransverseImpactParameter = cms.double(100.)
+    process.ak4PFJetsRecoTauChargedHadrons.builders[1].qualityCuts.vxAssocQualityCuts.maxTransverseImpactParameter = cms.double(100.)
+    process.ak4PFJetsRecoTauChargedHadrons.builders[1].qualityCuts.pvFindingAlgo = cms.string('highestPtInEvent')
+
+    # chargedPFCandidates from PFNeutralHadrons ... yes, from neutrals too, nothing is thrown away
+    process.ak4PFJetsRecoTauChargedHadrons.builders[2].qualityCuts.signalQualityCuts.maxDeltaZ = cms.double(100.)
+    process.ak4PFJetsRecoTauChargedHadrons.builders[2].qualityCuts.signalQualityCuts.maxTrackChi2 = cms.double(1000.)
+    process.ak4PFJetsRecoTauChargedHadrons.builders[2].qualityCuts.signalQualityCuts.maxTransverseImpactParameter = cms.double(100.)
+    process.ak4PFJetsRecoTauChargedHadrons.builders[2].qualityCuts.vxAssocQualityCuts.maxTransverseImpactParameter = cms.double(100.)
+    process.ak4PFJetsRecoTauChargedHadrons.builders[2].qualityCuts.pvFindingAlgo = cms.string('highestPtInEvent')

--- a/Production/src/Selectors.cc
+++ b/Production/src/Selectors.cc
@@ -171,10 +171,7 @@ TauJetSelector::Result TauJetTag::Select(const edm::Event& event, const std::deq
 {
     std::vector<const TauJet*> selected;
     for(const TauJet& tauJet :tauJets) {
-      const ObjPtr<reco_tau::gen_truth::GenLepton>& genLepton = tauJet.genLepton;
-      const ObjPtr<const reco::GenJet>& genJet = tauJet.genJet;
-      const ObjPtr<const pat::Jet>& jet = tauJet.jet;
-      if(genLepton || genJet || jet)
+      if(tauJet.genLepton || tauJet.genJet || tauJet.jet)
         selected.push_back(&tauJet);
     }
     return Result(selected, nullptr);

--- a/Production/src/Selectors.cc
+++ b/Production/src/Selectors.cc
@@ -177,7 +177,6 @@ TauJetSelector::Result TauJetTag::Select(const edm::Event& event, const std::deq
       if(genLepton || genJet || jet)
         selected.push_back(&tauJet);
     }
-    if(selected.empty()) return {};
     return Result(selected, nullptr);
 }
 

--- a/Production/src/Selectors.cc
+++ b/Production/src/Selectors.cc
@@ -174,12 +174,8 @@ TauJetSelector::Result TauJetTag::Select(const edm::Event& event, const std::deq
       const ObjPtr<reco_tau::gen_truth::GenLepton>& genLepton = tauJet.genLepton;
       const ObjPtr<const reco::GenJet>& genJet = tauJet.genJet;
       const ObjPtr<const pat::Jet>& jet = tauJet.jet;
-      const ObjPtr<const pat::Jet>& fatJet = tauJet.fatJet;
-      if((genLepton && jet) || (genLepton && fatJet)) {
+      if(genLepton || genJet || jet)
         selected.push_back(&tauJet);
-      } else if((genJet && jet) || (genJet && fatJet)) {
-        selected.push_back(&tauJet);
-      }
     }
     if(selected.empty()) return {};
     return Result(selected, nullptr);


### PR DESCRIPTION
Hi All,

In this PR: little customization for displaced tau reconstruction is added and few inconsistencies for tauReco at MiniAOD level is fixed. For the description of PR parts, please read below:

1) For the compatibility with current tupling working flow—selector is added with the naming `TauJetTag`. `TauJetTag` selects the events with the condition of having genLepton/genJet matched to the Jet/fatJet. Some space is left to add gen object selection criteria in the future PRs. This selector is needed to (a) to drop events with only boostedTau (since it is not supposed to be filled in some cases not to have empty events) (b) to have better control over matching then just using requireGenMatch flag. Also, it might be interesting to further have a Jet-Based selector in case we switch to Jet tagging at some point, so might be relevant not only for displaced. This requires discussion.

2) There was some modification of [`adaptToRunAtMiniAOD module`](https://github.com/cms-sw/cmssw/blob/master/RecoTauTag/Configuration/python/tools/adaptToRunAtMiniAOD.py) so I modified correspondingly the way of calling this and added it to the path (why before we did not need it? Because it was substituting the default path name?)

3) Setups for the `loose HPS` reconstruction is added in separate file containing Ricardo’s setups + what Sara did for HLT.