### PR TITLE
Added MC DY for 2024 as option

### DIFF
--- a/Production/crab/configs/Run3Summer24MiniAODv6/DY.yaml
+++ b/Production/crab/configs/Run3Summer24MiniAODv6/DY.yaml
@@ -1,0 +1,15 @@
+config:
+  params:
+    cmsRunOptions: "sampleType=MC,era=Run3"
+
+
+DYto2Tau_M-10to50: /DYto2Tau_Bin-MLL-10to50_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24MiniAODv6-150X_mcRun3_2024_realistic_v2-v2/MINIAODSIM
+DYto2Tau_M-50to120: /DYto2Tau_Bin-MLL-50to120_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24MiniAODv6-150X_mcRun3_2024_realistic_v2-v2/MINIAODSIM
+DYto2Tau_M-120to200: /DYto2Tau_Bin-MLL-120to200_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24MiniAODv6-150X_mcRun3_2024_realistic_v2-v2/MINIAODSIM
+DYto2Tau_M-200to400: /DYto2Tau_Bin-MLL-200to400_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24MiniAODv6-150X_mcRun3_2024_realistic_v2-v2/MINIAODSIM
+DYto2Tau_M-400to800: /DYto2Tau_Bin-MLL-400to800_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24MiniAODv6-150X_mcRun3_2024_realistic_v2-v2/MINIAODSIM
+DYto2Tau_M-800to1500: /DYto2Tau_Bin-MLL-800to1500_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24MiniAODv6-150X_mcRun3_2024_realistic_v2-v2/MINIAODSIM
+DYto2Tau_M-1500to2500: /DYto2Tau_Bin-MLL-1500to2500_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24MiniAODv6-150X_mcRun3_2024_realistic_v2-v2/MINIAODSIM
+DYto2Tau_M-2500to4000: /DYto2Tau_Bin-MLL-2500to4000_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24MiniAODv6-150X_mcRun3_2024_realistic_v2-v2/MINIAODSIM
+DYto2Tau_M-4000to6000: /DYto2Tau_Bin-MLL-4000to6000_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24MiniAODv6-150X_mcRun3_2024_realistic_v2-v2/MINIAODSIM
+DYto2Tau_M-6000: /DYto2Tau_Bin-MLL-6000_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24MiniAODv6-150X_mcRun3_2024_realistic_v2-v2/MINIAODSIM

--- a/Production/python/Production.py
+++ b/Production/python/Production.py
@@ -55,7 +55,7 @@ options.register('runTauSpinner', False, VarParsing.multiplicity.singleton, VarP
 
 options.parseArguments()
 
-import importlib
+import importlib.util
 import os
 import sys
 

--- a/Production/python/sampleConfig.py
+++ b/Production/python/sampleConfig.py
@@ -9,6 +9,7 @@ class Era(Enum):
     Run2_2017 = 2
     Run2_2018 = 3
     Run3_2022 = 4
+    Run3_2024 = 5
     Phase2_110X = 100
     Phase2_111X = 101
     Phase2_113X = 102
@@ -29,6 +30,7 @@ _globalTagDict = {
     (Era.Run2_2018, SampleType.Data) : 'auto:run2_data',
     (Era.Run3_2022, SampleType.MC) : 'auto:phase1_2022_realistic',
     (Era.Run3_2022, SampleType.Data) : 'auto:run3_data',
+    (Era.Run3_2024, SampleType.MC) : '150X_mcRun3_2024_realistic_v2',
     (Era.Phase2_110X, SampleType.MC) : '110X_mcRun4_realistic_v3',
     (Era.Phase2_111X, SampleType.MC) : 'auto:phase2_realistic_T15',
     (Era.Phase2_113X, SampleType.MC) : 'auto:phase2_realistic_T15',

--- a/Production/python/sampleConfig.py
+++ b/Production/python/sampleConfig.py
@@ -67,6 +67,9 @@ def getEraCfg(era):
     elif era == Era.Run3_2022:
         from Configuration.Eras.Era_Run3_cff import Run3
         return Run3
+    elif era == Era.Run3_2024:
+        from Configuration.Eras.Era_Run3_cff import Run3
+        return Run3
     elif isPhase2(era):
         from Configuration.Eras.Era_Phase2C9_cff import Phase2C9
         return Phase2C9


### PR DESCRIPTION
Added MC DY for 2024 as an option in preparation for Tau Reco ML studies for Phase 2

Note: specifically requesting the import of `importlib.util` was done to fix the following problem: 
```
An exception of category 'ConfigFileReadError' occurred while
   [0] Processing the python configuration file named Production/python/Production.py
Exception Message:
 unknown python problem occurred.
AttributeError: module 'importlib' has no attribute 'util'
```

It is possible that the problem originates from some library dependence in the python version used by CMSSW 15_0_2 